### PR TITLE
Add missing track name in update request body

### DIFF
--- a/lib/edits.js
+++ b/lib/edits.js
@@ -85,6 +85,7 @@ function trackVersionCode(appEdit, options, versionCode) {
             packageName: options.applicationId,
             track: options.track,
             requestBody: {
+                track: options.track,
                 releases: [
                     {
                         userFraction: options.userFraction,

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -88,6 +88,7 @@ async function trackVersionCode(appEdit: AppEdit, options: EditOptions, versionC
             packageName: options.applicationId,
             track: options.track,
             requestBody: {
+                track: options.track,
                 releases: [
                     {
                         userFraction: options.userFraction,


### PR DESCRIPTION
The track name was missing in the track update request body which led to [this](https://github.com/r0adkll/upload-google-play/issues/6) issue. Taken form [this](https://developers.google.com/android-publisher/api-ref/edits/tracks#resource) documentation, the track name is also required in the request body.

Closes #6