### PR TITLE
Add support for uploading multiple release artifacts to the same edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The service account json in plain text, provided via a secret, etc.
 
 **Required:** The package name, or Application Id, of the app you are uploading
 
-### `releaseFile`
+### `releaseFiles`
 
-**Required:** The Android release file to upload (.apk or .aab) 
+**Required:** The Android release file(s) to upload (.apk or .aab). Multiple files are separated by ','.
 
 ### `track`
 

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: 'The package name, or Application Id, of the app you are uploading'
     required: true
   releaseFiles:
-    description: 'The Android release file(s) to upload (.apk or .aab). Separated by  a \',\' for multiple artifacts'
+    description: "The Android release file(s) to upload (.apk or .aab). Separated by  a ',' for multiple artifacts"
     required: true
   track:
     description: 'The track in which you want to assign the uploaded app.'

--- a/action.yml
+++ b/action.yml
@@ -14,8 +14,8 @@ inputs:
   packageName:
     description: 'The package name, or Application Id, of the app you are uploading'
     required: true
-  releaseFile:
-    description: 'The Android release file to upload (.apk or .aab)'
+  releaseFiles:
+    description: 'The Android release file(s) to upload (.apk or .aab). Separated by  a \',\' for multiple artifacts'
     required: true
   track:
     description: 'The track in which you want to assign the uploaded app.'

--- a/lib/edits.js
+++ b/lib/edits.js
@@ -40,7 +40,7 @@ function uploadToPlayStore(options, releaseFiles) {
         // Check the 'track' for 'internalsharing', if so switch to a non-track api
         if (options.track === 'internalsharing') {
             core.debug("Track is Internal app sharing, switch to special upload api");
-            for (const releaseFile in releaseFiles) {
+            for (const releaseFile of releaseFiles) {
                 core.debug(`Uploading ${releaseFile}`);
                 yield uploadInternalSharingRelease(options, releaseFile).catch(reason => {
                     core.setFailed(reason);
@@ -61,7 +61,7 @@ function uploadToPlayStore(options, releaseFiles) {
             });
             // Upload artifacts to Google Play, and store their version codes
             var versionCodes = new Array();
-            for (const releaseFile in releaseFiles) {
+            for (const releaseFile of releaseFiles) {
                 core.debug(`Uploading ${releaseFile}`);
                 const versionCode = yield uploadRelease(appEdit.data, options, releaseFile).catch(reason => {
                     core.setFailed(reason);

--- a/lib/edits.js
+++ b/lib/edits.js
@@ -38,7 +38,7 @@ const androidPublisher = googleapis_1.google.androidpublisher('v3');
 function uploadToPlayStore(options, releaseFiles) {
     return __awaiter(this, void 0, void 0, function* () {
         // Check the 'track' for 'internalsharing', if so switch to a non-track api
-        if (options.track === 'internalappsharing') {
+        if (options.track === 'internalsharing') {
             core.debug("Track is Internal app sharing, switch to special upload api");
             releaseFiles.forEach((releaseFile) => __awaiter(this, void 0, void 0, function* () {
                 core.debug(`Uploading ${releaseFile}`);

--- a/lib/edits.js
+++ b/lib/edits.js
@@ -103,7 +103,6 @@ function uploadInternalSharingRelease(options, releaseFile) {
             return Promise.resolve(res.downloadUrl);
         }
         else {
-            core.setFailed(`${releaseFile} is invalid`);
             return Promise.reject(`${releaseFile} is invalid`);
         }
     });
@@ -121,7 +120,6 @@ function uploadRelease(appEdit, options, releaseFile) {
             return Promise.resolve(bundle.versionCode);
         }
         else {
-            core.setFailed(`${releaseFile} is invalid`);
             return Promise.reject(`${releaseFile} is invalid`);
         }
     });
@@ -135,8 +133,7 @@ function validateSelectedTrack(appEdit, options) {
         });
         const allTracks = res.data.tracks;
         if (allTracks == undefined || allTracks.find(value => value.track == options.track) == undefined) {
-            core.setFailed(`Track "${options.track}" could not be found `);
-            return Promise.reject(`No track found for "${options.track}"`);
+            return Promise.reject(`Track "${options.track}" could not be found `);
         }
     });
 }
@@ -163,7 +160,7 @@ function addReleasesToTrack(appEdit, options, versionCodes) {
                         userFraction: options.userFraction,
                         status: status,
                         releaseNotes: yield whatsnew_1.readLocalizedReleaseNotes(options.whatsNewDir),
-                        versionCodes: versionCodes.map(x => x.toString())
+                        versionCodes: versionCodes.filter(x => x != 0).map(x => x.toString())
                     }
                 ]
             }

--- a/lib/edits.js
+++ b/lib/edits.js
@@ -40,13 +40,13 @@ function uploadToPlayStore(options, releaseFiles) {
         // Check the 'track' for 'internalsharing', if so switch to a non-track api
         if (options.track === 'internalsharing') {
             core.debug("Track is Internal app sharing, switch to special upload api");
-            releaseFiles.forEach((releaseFile) => __awaiter(this, void 0, void 0, function* () {
+            for (const releaseFile in releaseFiles) {
                 core.debug(`Uploading ${releaseFile}`);
                 yield uploadInternalSharingRelease(options, releaseFile).catch(reason => {
                     core.setFailed(reason);
                     return Promise.reject(reason);
                 });
-            }));
+            }
         }
         else {
             // Create a new Edit
@@ -61,16 +61,16 @@ function uploadToPlayStore(options, releaseFiles) {
             });
             // Upload artifacts to Google Play, and store their version codes
             var versionCodes = new Array();
-            releaseFiles.forEach((releaseFile) => __awaiter(this, void 0, void 0, function* () {
+            for (const releaseFile in releaseFiles) {
                 core.debug(`Uploading ${releaseFile}`);
                 const versionCode = yield uploadRelease(appEdit.data, options, releaseFile).catch(reason => {
                     core.setFailed(reason);
                     return Promise.reject(reason);
                 });
                 versionCodes.push(versionCode);
-            }));
+            }
             // Add the uploaded artifacts to the Edit track
-            const track = addReleasesToTrack(appEdit.data, options, versionCodes);
+            const track = yield addReleasesToTrack(appEdit.data, options, versionCodes);
             // Commit the pending Edit
             const res = yield androidPublisher.edits.commit({
                 auth: options.auth,

--- a/lib/edits.js
+++ b/lib/edits.js
@@ -28,66 +28,81 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.uploadRelease = void 0;
+exports.uploadToPlayStore = void 0;
 const core = __importStar(require("@actions/core"));
 const fs = __importStar(require("fs"));
 const fs_1 = require("fs");
 const googleapis_1 = require("googleapis");
 const whatsnew_1 = require("./whatsnew");
 const androidPublisher = googleapis_1.google.androidpublisher('v3');
-function uploadRelease(options, releaseFiles) {
+function uploadToPlayStore(options, releaseFiles) {
     return __awaiter(this, void 0, void 0, function* () {
-        // Check the 'track' for 'internalsharing', if so switch to a non-track api
-        if (options.track === 'internalsharing') {
-            core.debug("Track is Internal app sharing, switch to special upload api");
-            releaseFiles.forEach((releaseFile) => __awaiter(this, void 0, void 0, function* () {
-                // if (releaseFile.endsWith('.apk')) {
-                //     const res = await internalSharingUploadApk(options, releaseFile)
-                //     return Promise.resolve(res.downloadUrl)
-                // } else if (releaseFile.endsWith('.aab')) {
-                //     const res = await internalSharingUploadBundle(options, releaseFile)
-                //     return Promise.resolve(res.downloadUrl)
-                // } else {
-                //     return Promise.reject(`Unrecognized Release File`)
-                // }
-            }));
-        }
         const appEdit = yield androidPublisher.edits.insert({
             auth: options.auth,
             packageName: options.applicationId
         });
-        const allTracks = yield getAllTracks(appEdit.data, options);
+        releaseFiles.forEach((releaseFile) => __awaiter(this, void 0, void 0, function* () {
+            core.debug(`Uploading ${releaseFile}`);
+            yield uploadRelease(appEdit.data, options, releaseFile).catch(reason => {
+                return Promise.reject(reason);
+            });
+        }));
+        const res = yield androidPublisher.edits.commit({
+            auth: options.auth,
+            editId: appEdit.data.id,
+            packageName: options.applicationId
+        });
+        if (res.data.id != null) {
+            core.debug(`Successfully committed ${res.data.id}`);
+            return Promise.resolve(res.data.id);
+        }
+        else {
+            core.setFailed(`Error ${res.status}: ${res.statusText}`);
+            return Promise.reject(res.status);
+        }
+    });
+}
+exports.uploadToPlayStore = uploadToPlayStore;
+function uploadRelease(appEdit, options, releaseFile) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // Check the 'track' for 'internalsharing', if so switch to a non-track api
+        if (options.track === 'internalsharing') {
+            core.debug("Track is Internal app sharing, switch to special upload api");
+            if (releaseFile.endsWith('.apk')) {
+                const res = yield internalSharingUploadApk(options, releaseFile);
+                return Promise.resolve(res.downloadUrl);
+            }
+            else if (releaseFile.endsWith('.aab')) {
+                const res = yield internalSharingUploadBundle(options, releaseFile);
+                return Promise.resolve(res.downloadUrl);
+            }
+            else {
+                core.setFailed(`${releaseFile} is invalid`);
+                return Promise.reject(`${releaseFile} is invalid`);
+            }
+        }
+        const allTracks = yield getAllTracks(appEdit, options);
         if (allTracks == undefined || allTracks.find(value => value.track == options.track) == undefined) {
             core.setFailed(`Track "${options.track}" could not be found `);
             return Promise.reject(`No track found for "${options.track}"`);
         }
         let track = undefined;
-        releaseFiles.forEach((releaseFile) => __awaiter(this, void 0, void 0, function* () {
-            if (releaseFile.endsWith('.apk')) {
-                const apk = yield uploadApk(appEdit.data, options, releaseFile);
-                yield uploadMappingFile(appEdit.data, apk.versionCode, options);
-                track = yield trackVersionCode(appEdit.data, options, apk.versionCode);
-            }
-            else if (releaseFile.endsWith('.aab')) {
-                const bundle = yield uploadBundle(appEdit.data, options, releaseFile);
-                yield uploadMappingFile(appEdit.data, bundle.versionCode, options);
-                track = yield trackVersionCode(appEdit.data, options, bundle.versionCode);
-            }
-            else {
-                return Promise.reject("Invalid release file");
-            }
-        }));
-        if (track != undefined) {
-            const res = yield androidPublisher.edits.commit({
-                auth: options.auth,
-                editId: appEdit.data.id,
-                packageName: options.applicationId
-            });
-            core.debug(`Committed release with Id(${res.data.id}) and Track: ${track}`);
+        if (releaseFile.endsWith('.apk')) {
+            const apk = yield uploadApk(appEdit, options, releaseFile);
+            yield uploadMappingFile(appEdit, apk.versionCode, options);
+            track = yield trackVersionCode(appEdit, options, apk.versionCode);
+        }
+        else if (releaseFile.endsWith('.aab')) {
+            const bundle = yield uploadBundle(appEdit, options, releaseFile);
+            yield uploadMappingFile(appEdit, bundle.versionCode, options);
+            track = yield trackVersionCode(appEdit, options, bundle.versionCode);
+        }
+        else {
+            core.setFailed(`${releaseFile} is invalid`);
+            return Promise.reject(`${releaseFile} is invalid`);
         }
     });
 }
-exports.uploadRelease = uploadRelease;
 function getAllTracks(appEdit, options) {
     return __awaiter(this, void 0, void 0, function* () {
         const res = yield androidPublisher.edits.tracks.list({

--- a/lib/edits.js
+++ b/lib/edits.js
@@ -1,4 +1,23 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -8,36 +27,30 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.uploadRelease = void 0;
 const core = __importStar(require("@actions/core"));
 const fs = __importStar(require("fs"));
 const fs_1 = require("fs");
 const googleapis_1 = require("googleapis");
 const whatsnew_1 = require("./whatsnew");
 const androidPublisher = googleapis_1.google.androidpublisher('v3');
-function uploadRelease(options, releaseFile) {
+function uploadRelease(options, releaseFiles) {
     return __awaiter(this, void 0, void 0, function* () {
         // Check the 'track' for 'internalsharing', if so switch to a non-track api
         if (options.track === 'internalsharing') {
             core.debug("Track is Internal app sharing, switch to special upload api");
-            if (releaseFile.endsWith('.apk')) {
-                const res = yield internalSharingUploadApk(options, releaseFile);
-                return Promise.resolve(res.downloadUrl);
-            }
-            else if (releaseFile.endsWith('.aab')) {
-                const res = yield internalSharingUploadBundle(options, releaseFile);
-                return Promise.resolve(res.downloadUrl);
-            }
-            else {
-                return Promise.reject(`Unrecognized Release File`);
-            }
+            releaseFiles.forEach((releaseFile) => __awaiter(this, void 0, void 0, function* () {
+                // if (releaseFile.endsWith('.apk')) {
+                //     const res = await internalSharingUploadApk(options, releaseFile)
+                //     return Promise.resolve(res.downloadUrl)
+                // } else if (releaseFile.endsWith('.aab')) {
+                //     const res = await internalSharingUploadBundle(options, releaseFile)
+                //     return Promise.resolve(res.downloadUrl)
+                // } else {
+                //     return Promise.reject(`Unrecognized Release File`)
+                // }
+            }));
         }
         const appEdit = yield androidPublisher.edits.insert({
             auth: options.auth,
@@ -49,19 +62,21 @@ function uploadRelease(options, releaseFile) {
             return Promise.reject(`No track found for "${options.track}"`);
         }
         let track = undefined;
-        if (releaseFile.endsWith('.apk')) {
-            const apk = yield uploadApk(appEdit.data, options, releaseFile);
-            yield uploadMappingFile(appEdit.data, apk.versionCode, options);
-            track = yield trackVersionCode(appEdit.data, options, apk.versionCode);
-        }
-        else if (releaseFile.endsWith('.aab')) {
-            const bundle = yield uploadBundle(appEdit.data, options, releaseFile);
-            yield uploadMappingFile(appEdit.data, bundle.versionCode, options);
-            track = yield trackVersionCode(appEdit.data, options, bundle.versionCode);
-        }
-        else {
-            return Promise.reject("Invalid release file");
-        }
+        releaseFiles.forEach((releaseFile) => __awaiter(this, void 0, void 0, function* () {
+            if (releaseFile.endsWith('.apk')) {
+                const apk = yield uploadApk(appEdit.data, options, releaseFile);
+                yield uploadMappingFile(appEdit.data, apk.versionCode, options);
+                track = yield trackVersionCode(appEdit.data, options, apk.versionCode);
+            }
+            else if (releaseFile.endsWith('.aab')) {
+                const bundle = yield uploadBundle(appEdit.data, options, releaseFile);
+                yield uploadMappingFile(appEdit.data, bundle.versionCode, options);
+                track = yield trackVersionCode(appEdit.data, options, bundle.versionCode);
+            }
+            else {
+                return Promise.reject("Invalid release file");
+            }
+        }));
         if (track != undefined) {
             const res = yield androidPublisher.edits.commit({
                 auth: options.auth,

--- a/lib/edits.js
+++ b/lib/edits.js
@@ -37,65 +37,64 @@ const whatsnew_1 = require("./whatsnew");
 const androidPublisher = googleapis_1.google.androidpublisher('v3');
 function uploadToPlayStore(options, releaseFiles) {
     return __awaiter(this, void 0, void 0, function* () {
-        const appEdit = yield androidPublisher.edits.insert({
-            auth: options.auth,
-            packageName: options.applicationId
-        });
-        releaseFiles.forEach((releaseFile) => __awaiter(this, void 0, void 0, function* () {
-            core.debug(`Uploading ${releaseFile}`);
-            yield uploadRelease(appEdit.data, options, releaseFile).catch(reason => {
-                return Promise.reject(reason);
-            });
-        }));
-        const res = yield androidPublisher.edits.commit({
-            auth: options.auth,
-            editId: appEdit.data.id,
-            packageName: options.applicationId
-        });
-        if (res.data.id != null) {
-            core.debug(`Successfully committed ${res.data.id}`);
-            return Promise.resolve(res.data.id);
+        if (options.track === 'internalappsharing') {
+            core.debug("Track is Internal app sharing, switch to special upload api");
+            releaseFiles.forEach((releaseFile) => __awaiter(this, void 0, void 0, function* () {
+                core.debug(`Uploading ${releaseFile}`);
+                yield uploadInternalSharingRelease(options, releaseFile).catch(reason => {
+                    core.setFailed(reason);
+                    return Promise.reject(reason);
+                });
+            }));
         }
         else {
-            core.setFailed(`Error ${res.status}: ${res.statusText}`);
-            return Promise.reject(res.status);
+            const appEdit = yield androidPublisher.edits.insert({
+                auth: options.auth,
+                packageName: options.applicationId
+            });
+            yield validateSelectedTrack(appEdit.data, options).catch(reason => {
+                core.setFailed(reason);
+                return Promise.reject(reason);
+            });
+            // Check the 'track' for 'internalsharing', if so switch to a non-track api
+            var versionCodes = new Array();
+            releaseFiles.forEach((releaseFile) => __awaiter(this, void 0, void 0, function* () {
+                core.debug(`Uploading ${releaseFile}`);
+                const versionCode = yield uploadRelease(appEdit.data, options, releaseFile).catch(reason => {
+                    core.setFailed(reason);
+                    return Promise.reject(reason);
+                });
+                versionCodes.push(versionCode);
+            }));
+            const track = addReleasesToTrack(appEdit.data, options, versionCodes);
+            const res = yield androidPublisher.edits.commit({
+                auth: options.auth,
+                editId: appEdit.data.id,
+                packageName: options.applicationId
+            });
+            if (res.data.id != null) {
+                core.debug(`Successfully committed ${res.data.id}`);
+                return Promise.resolve(res.data.id);
+            }
+            else {
+                core.setFailed(`Error ${res.status}: ${res.statusText}`);
+                return Promise.reject(res.status);
+            }
         }
     });
 }
 exports.uploadToPlayStore = uploadToPlayStore;
-function uploadRelease(appEdit, options, releaseFile) {
+function uploadInternalSharingRelease(options, releaseFile) {
     return __awaiter(this, void 0, void 0, function* () {
-        // Check the 'track' for 'internalsharing', if so switch to a non-track api
-        if (options.track === 'internalsharing') {
-            core.debug("Track is Internal app sharing, switch to special upload api");
-            if (releaseFile.endsWith('.apk')) {
-                const res = yield internalSharingUploadApk(options, releaseFile);
-                return Promise.resolve(res.downloadUrl);
-            }
-            else if (releaseFile.endsWith('.aab')) {
-                const res = yield internalSharingUploadBundle(options, releaseFile);
-                return Promise.resolve(res.downloadUrl);
-            }
-            else {
-                core.setFailed(`${releaseFile} is invalid`);
-                return Promise.reject(`${releaseFile} is invalid`);
-            }
-        }
-        const allTracks = yield getAllTracks(appEdit, options);
-        if (allTracks == undefined || allTracks.find(value => value.track == options.track) == undefined) {
-            core.setFailed(`Track "${options.track}" could not be found `);
-            return Promise.reject(`No track found for "${options.track}"`);
-        }
-        let track = undefined;
         if (releaseFile.endsWith('.apk')) {
-            const apk = yield uploadApk(appEdit, options, releaseFile);
-            yield uploadMappingFile(appEdit, apk.versionCode, options);
-            track = yield trackVersionCode(appEdit, options, apk.versionCode);
+            const res = yield internalSharingUploadApk(options, releaseFile);
+            console.log(`${releaseFile} uploaded to Internal Sharing, download it with ${res.downloadUrl}`);
+            return Promise.resolve(res.downloadUrl);
         }
         else if (releaseFile.endsWith('.aab')) {
-            const bundle = yield uploadBundle(appEdit, options, releaseFile);
-            yield uploadMappingFile(appEdit, bundle.versionCode, options);
-            track = yield trackVersionCode(appEdit, options, bundle.versionCode);
+            const res = yield internalSharingUploadBundle(options, releaseFile);
+            console.log(`${releaseFile} uploaded to Internal Sharing, download it with ${res.downloadUrl}`);
+            return Promise.resolve(res.downloadUrl);
         }
         else {
             core.setFailed(`${releaseFile} is invalid`);
@@ -103,17 +102,39 @@ function uploadRelease(appEdit, options, releaseFile) {
         }
     });
 }
-function getAllTracks(appEdit, options) {
+function uploadRelease(appEdit, options, releaseFile) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (releaseFile.endsWith('.apk')) {
+            const apk = yield uploadApk(appEdit, options, releaseFile);
+            yield uploadMappingFile(appEdit, apk.versionCode, options);
+            return Promise.resolve(apk.versionCode);
+        }
+        else if (releaseFile.endsWith('.aab')) {
+            const bundle = yield uploadBundle(appEdit, options, releaseFile);
+            yield uploadMappingFile(appEdit, bundle.versionCode, options);
+            return Promise.resolve(bundle.versionCode);
+        }
+        else {
+            core.setFailed(`${releaseFile} is invalid`);
+            return Promise.reject(`${releaseFile} is invalid`);
+        }
+    });
+}
+function validateSelectedTrack(appEdit, options) {
     return __awaiter(this, void 0, void 0, function* () {
         const res = yield androidPublisher.edits.tracks.list({
             auth: options.auth,
             editId: appEdit.id,
             packageName: options.applicationId
         });
-        return res.data.tracks;
+        const allTracks = res.data.tracks;
+        if (allTracks == undefined || allTracks.find(value => value.track == options.track) == undefined) {
+            core.setFailed(`Track "${options.track}" could not be found `);
+            return Promise.reject(`No track found for "${options.track}"`);
+        }
     });
 }
-function trackVersionCode(appEdit, options, versionCode) {
+function addReleasesToTrack(appEdit, options, versionCodes) {
     return __awaiter(this, void 0, void 0, function* () {
         let status;
         if (options.userFraction != undefined) {
@@ -122,7 +143,7 @@ function trackVersionCode(appEdit, options, versionCode) {
         else {
             status = 'completed';
         }
-        core.debug(`Creating Track Release for Edit(${appEdit.id}) for Track(${options.track}) with a UserFraction(${options.userFraction}) and VersionCode(${versionCode})`);
+        core.debug(`Creating Track Release for Edit(${appEdit.id}) for Track(${options.track}) with a UserFraction(${options.userFraction}) and VersionCodes(${versionCodes})`);
         const res = yield androidPublisher.edits.tracks
             .update({
             auth: options.auth,
@@ -136,9 +157,7 @@ function trackVersionCode(appEdit, options, versionCode) {
                         userFraction: options.userFraction,
                         status: status,
                         releaseNotes: yield whatsnew_1.readLocalizedReleaseNotes(options.whatsNewDir),
-                        versionCodes: [
-                            versionCode.toString()
-                        ]
+                        versionCodes: versionCodes.map(x => x.toString())
                     }
                 ]
             }

--- a/lib/edits.js
+++ b/lib/edits.js
@@ -37,6 +37,7 @@ const whatsnew_1 = require("./whatsnew");
 const androidPublisher = googleapis_1.google.androidpublisher('v3');
 function uploadToPlayStore(options, releaseFiles) {
     return __awaiter(this, void 0, void 0, function* () {
+        // Check the 'track' for 'internalsharing', if so switch to a non-track api
         if (options.track === 'internalappsharing') {
             core.debug("Track is Internal app sharing, switch to special upload api");
             releaseFiles.forEach((releaseFile) => __awaiter(this, void 0, void 0, function* () {
@@ -48,15 +49,17 @@ function uploadToPlayStore(options, releaseFiles) {
             }));
         }
         else {
+            // Create a new Edit
             const appEdit = yield androidPublisher.edits.insert({
                 auth: options.auth,
                 packageName: options.applicationId
             });
+            // Validate the given track
             yield validateSelectedTrack(appEdit.data, options).catch(reason => {
                 core.setFailed(reason);
                 return Promise.reject(reason);
             });
-            // Check the 'track' for 'internalsharing', if so switch to a non-track api
+            // Upload artifacts to Google Play, and store their version codes
             var versionCodes = new Array();
             releaseFiles.forEach((releaseFile) => __awaiter(this, void 0, void 0, function* () {
                 core.debug(`Uploading ${releaseFile}`);
@@ -66,12 +69,15 @@ function uploadToPlayStore(options, releaseFiles) {
                 });
                 versionCodes.push(versionCode);
             }));
+            // Add the uploaded artifacts to the Edit track
             const track = addReleasesToTrack(appEdit.data, options, versionCodes);
+            // Commit the pending Edit
             const res = yield androidPublisher.edits.commit({
                 auth: options.auth,
                 editId: appEdit.data.id,
                 packageName: options.applicationId
             });
+            // Simple check to see whether commit was successful
             if (res.data.id != null) {
                 core.debug(`Successfully committed ${res.data.id}`);
                 return Promise.resolve(res.data.id);

--- a/lib/main.js
+++ b/lib/main.js
@@ -76,12 +76,12 @@ function run() {
                 userFractionFloat = undefined;
             }
             // Check release files
-            releaseFiles.forEach(releaseFile => {
+            for (const releaseFile in releaseFiles) {
                 if (!fs.existsSync(releaseFile)) {
                     core.setFailed(`Unable to find release file @ ${releaseFile}`);
                     return;
                 }
-            });
+            }
             if (whatsNewDir != undefined && whatsNewDir.length > 0 && !fs.existsSync(whatsNewDir)) {
                 core.setFailed(`Unable to find 'whatsnew' directory @ ${whatsNewDir}`);
                 return;

--- a/lib/main.js
+++ b/lib/main.js
@@ -91,7 +91,7 @@ function run() {
                 return;
             }
             const authClient = yield auth.getClient();
-            const downloadUrl = yield edits_1.uploadRelease({
+            const downloadUrl = yield edits_1.uploadToPlayStore({
                 auth: authClient,
                 applicationId: packageName,
                 track: track,

--- a/lib/main.js
+++ b/lib/main.js
@@ -76,8 +76,7 @@ function run() {
                 userFractionFloat = undefined;
             }
             // Check release files
-            core.debug(`Checking release files ${releaseFiles}`);
-            for (const releaseFile in releaseFiles) {
+            for (const releaseFile of releaseFiles) {
                 core.debug(`Validating ${releaseFile} exists`);
                 if (!fs.existsSync(releaseFile)) {
                     core.setFailed(`Unable to find release file @ ${releaseFile}`);

--- a/lib/main.js
+++ b/lib/main.js
@@ -41,7 +41,7 @@ function run() {
             const serviceAccountJson = core.getInput('serviceAccountJson', { required: false });
             const serviceAccountJsonRaw = core.getInput('serviceAccountJsonPlainText', { required: false });
             const packageName = core.getInput('packageName', { required: true });
-            const releaseFiles = core.getInput('releaseFile', { required: true }).split(',').filter(x => x !== '');
+            const releaseFiles = core.getInput('releaseFiles', { required: true }).split(',').filter(x => x !== '');
             const track = core.getInput('track', { required: true });
             const userFraction = core.getInput('userFraction', { required: false });
             const whatsNewDir = core.getInput('whatsNewDirectory', { required: false });

--- a/lib/main.js
+++ b/lib/main.js
@@ -41,7 +41,7 @@ function run() {
             const serviceAccountJson = core.getInput('serviceAccountJson', { required: false });
             const serviceAccountJsonRaw = core.getInput('serviceAccountJsonPlainText', { required: false });
             const packageName = core.getInput('packageName', { required: true });
-            const releaseFiles = core.getInput('releaseFile', { required: true }).split("|").filter(x => x !== "");
+            const releaseFiles = core.getInput('releaseFile', { required: true }).split(',').filter(x => x !== '');
             const track = core.getInput('track', { required: true });
             const userFraction = core.getInput('userFraction', { required: false });
             const whatsNewDir = core.getInput('whatsNewDirectory', { required: false });

--- a/lib/main.js
+++ b/lib/main.js
@@ -91,7 +91,7 @@ function run() {
                 return;
             }
             const authClient = yield auth.getClient();
-            const downloadUrl = yield edits_1.uploadToPlayStore({
+            yield edits_1.uploadToPlayStore({
                 auth: authClient,
                 applicationId: packageName,
                 track: track,
@@ -99,10 +99,6 @@ function run() {
                 whatsNewDir: whatsNewDir,
                 mappingFile: mappingFile
             }, releaseFiles);
-            if (downloadUrl) {
-                core.setOutput('internalSharingDownloadUrl', downloadUrl);
-                core.exportVariable('INTERNAL_SHARING_DOWNLOAD_URL', downloadUrl);
-            }
             console.log(`Finished uploading to the Play Store`);
         }
         catch (error) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -76,6 +76,7 @@ function run() {
                 userFractionFloat = undefined;
             }
             // Check release files
+            console.log(`Checking ${releaseFiles.length} files`);
             releaseFiles.forEach(releaseFile => {
                 if (!fs.existsSync(releaseFile)) {
                     core.setFailed(`Unable to find release file @ ${releaseFile}`);

--- a/lib/main.js
+++ b/lib/main.js
@@ -78,6 +78,7 @@ function run() {
             // Check release files
             core.debug(`Checking release files ${releaseFiles}`);
             for (const releaseFile in releaseFiles) {
+                core.debug(`Validating ${releaseFile} exists`);
                 if (!fs.existsSync(releaseFile)) {
                     core.setFailed(`Unable to find release file @ ${releaseFile}`);
                     return;

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,23 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -7,13 +26,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
-};
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
@@ -29,7 +41,7 @@ function run() {
             const serviceAccountJson = core.getInput('serviceAccountJson', { required: false });
             const serviceAccountJsonRaw = core.getInput('serviceAccountJsonPlainText', { required: false });
             const packageName = core.getInput('packageName', { required: true });
-            const releaseFile = core.getInput('releaseFile', { required: true });
+            const releaseFiles = core.getInput('releaseFile', { required: true }).split("|").filter(x => x !== "");
             const track = core.getInput('track', { required: true });
             const userFraction = core.getInput('userFraction', { required: false });
             const whatsNewDir = core.getInput('whatsNewDirectory', { required: false });
@@ -63,11 +75,13 @@ function run() {
             else {
                 userFractionFloat = undefined;
             }
-            // Check release file
-            if (!fs.existsSync(releaseFile)) {
-                core.setFailed(`Unable to find release file @ ${releaseFile}`);
-                return;
-            }
+            // Check release files
+            releaseFiles.forEach(releaseFile => {
+                if (!fs.existsSync(releaseFile)) {
+                    core.setFailed(`Unable to find release file @ ${releaseFile}`);
+                    return;
+                }
+            });
             if (whatsNewDir != undefined && whatsNewDir.length > 0 && !fs.existsSync(whatsNewDir)) {
                 core.setFailed(`Unable to find 'whatsnew' directory @ ${whatsNewDir}`);
                 return;
@@ -77,15 +91,19 @@ function run() {
                 return;
             }
             const authClient = yield auth.getClient();
-            yield edits_1.uploadRelease({
+            const downloadUrl = yield edits_1.uploadRelease({
                 auth: authClient,
                 applicationId: packageName,
                 track: track,
                 userFraction: userFractionFloat,
                 whatsNewDir: whatsNewDir,
                 mappingFile: mappingFile
-            }, releaseFile);
-            console.log(`Finished uploading ${releaseFile} to the Play Store`);
+            }, releaseFiles);
+            if (downloadUrl) {
+                core.setOutput('internalSharingDownloadUrl', downloadUrl);
+                core.exportVariable('INTERNAL_SHARING_DOWNLOAD_URL', downloadUrl);
+            }
+            console.log(`Finished uploading to the Play Store`);
         }
         catch (error) {
             core.setFailed(error.message);

--- a/lib/main.js
+++ b/lib/main.js
@@ -76,6 +76,7 @@ function run() {
                 userFractionFloat = undefined;
             }
             // Check release files
+            core.debug(`Checking release files ${releaseFiles}`);
             for (const releaseFile in releaseFiles) {
                 if (!fs.existsSync(releaseFile)) {
                     core.setFailed(`Unable to find release file @ ${releaseFile}`);

--- a/lib/main.js
+++ b/lib/main.js
@@ -76,7 +76,6 @@ function run() {
                 userFractionFloat = undefined;
             }
             // Check release files
-            console.log(`Checking ${releaseFiles.length} files`);
             releaseFiles.forEach(releaseFile => {
                 if (!fs.existsSync(releaseFile)) {
                     core.setFailed(`Unable to find release file @ ${releaseFile}`);

--- a/lib/whatsnew.js
+++ b/lib/whatsnew.js
@@ -1,4 +1,23 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -8,14 +27,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.readLocalizedReleaseNotes = void 0;
 const core = __importStar(require("@actions/core"));
 const fs = __importStar(require("fs"));
 const path = __importStar(require("path"));

--- a/node_modules/node-fetch/CHANGELOG.md
+++ b/node_modules/node-fetch/CHANGELOG.md
@@ -5,6 +5,12 @@ Changelog
 
 # 2.x release
 
+## v2.6.1
+
+**This is an important security release. It is strongly recommended to update as soon as possible.**
+
+- Fix: honor the `size` option after following a redirect.
+
 ## v2.6.0
 
 - Enhance: `options.agent`, it now accepts a function that returns custom http(s).Agent instance based on current URL, see readme for more information.

--- a/node_modules/node-fetch/README.md
+++ b/node_modules/node-fetch/README.md
@@ -5,10 +5,13 @@ node-fetch
 [![build status][travis-image]][travis-url]
 [![coverage status][codecov-image]][codecov-url]
 [![install size][install-size-image]][install-size-url]
+[![Discord][discord-image]][discord-url]
 
 A light-weight module that brings `window.fetch` to Node.js
 
 (We are looking for [v2 maintainers and collaborators](https://github.com/bitinn/node-fetch/issues/567))
+
+[![Backers][opencollective-image]][opencollective-url]
 
 <!-- TOC -->
 
@@ -48,7 +51,7 @@ A light-weight module that brings `window.fetch` to Node.js
 
 ## Motivation
 
-Instead of implementing `XMLHttpRequest` in Node.js to run browser-specific [Fetch polyfill](https://github.com/github/fetch), why not go from native `http` to `fetch` API directly? Hence `node-fetch`, minimal code for a `window.fetch` compatible API on Node.js runtime.
+Instead of implementing `XMLHttpRequest` in Node.js to run browser-specific [Fetch polyfill](https://github.com/github/fetch), why not go from native `http` to `fetch` API directly? Hence, `node-fetch`, minimal code for a `window.fetch` compatible API on Node.js runtime.
 
 See Matt Andrews' [isomorphic-fetch](https://github.com/matthew-andrews/isomorphic-fetch) or Leonardo Quixada's [cross-fetch](https://github.com/lquixada/cross-fetch) for isomorphic usage (exports `node-fetch` for server-side, `whatwg-fetch` for client-side).
 
@@ -56,9 +59,9 @@ See Matt Andrews' [isomorphic-fetch](https://github.com/matthew-andrews/isomorph
 
 - Stay consistent with `window.fetch` API.
 - Make conscious trade-off when following [WHATWG fetch spec][whatwg-fetch] and [stream spec](https://streams.spec.whatwg.org/) implementation details, document known differences.
-- Use native promise, but allow substituting it with [insert your favorite promise library].
-- Use native Node streams for body, on both request and response.
-- Decode content encoding (gzip/deflate) properly, and convert string output (such as `res.text()` and `res.json()`) to UTF-8 automatically.
+- Use native promise but allow substituting it with [insert your favorite promise library].
+- Use native Node streams for body on both request and response.
+- Decode content encoding (gzip/deflate) properly and convert string output (such as `res.text()` and `res.json()`) to UTF-8 automatically.
 - Useful extensions such as timeout, redirect limit, response size limit, [explicit errors](ERROR-HANDLING.md) for troubleshooting.
 
 ## Difference from client-side fetch
@@ -72,16 +75,16 @@ See Matt Andrews' [isomorphic-fetch](https://github.com/matthew-andrews/isomorph
 Current stable release (`2.x`)
 
 ```sh
-$ npm install node-fetch --save
+$ npm install node-fetch
 ```
 
 ## Loading and configuring the module
-We suggest you load the module via `require`, pending the stabalizing of es modules in node:
+We suggest you load the module via `require` until the stabilization of ES modules in node:
 ```js
 const fetch = require('node-fetch');
 ```
 
-If you are using a Promise library other than native, set it through fetch.Promise:
+If you are using a Promise library other than native, set it through `fetch.Promise`:
 ```js
 const Bluebird = require('bluebird');
 
@@ -90,7 +93,7 @@ fetch.Promise = Bluebird;
 
 ## Common Usage
 
-NOTE: The documentation below is up-to-date with `2.x` releases, [see `1.x` readme](https://github.com/bitinn/node-fetch/blob/1.x/README.md), [changelog](https://github.com/bitinn/node-fetch/blob/1.x/CHANGELOG.md) and [2.x upgrade guide](UPGRADE-GUIDE.md) for the differences.
+NOTE: The documentation below is up-to-date with `2.x` releases; see the [`1.x` readme](https://github.com/bitinn/node-fetch/blob/1.x/README.md), [changelog](https://github.com/bitinn/node-fetch/blob/1.x/CHANGELOG.md) and [2.x upgrade guide](UPGRADE-GUIDE.md) for the differences.
 
 #### Plain text or HTML
 ```js
@@ -146,9 +149,9 @@ fetch('https://httpbin.org/post', { method: 'POST', body: params })
 ```
 
 #### Handling exceptions
-NOTE: 3xx-5xx responses are *NOT* exceptions, and should be handled in `then()`, see the next section.
+NOTE: 3xx-5xx responses are *NOT* exceptions and should be handled in `then()`; see the next section for more information.
 
-Adding a catch to the fetch promise chain will catch *all* exceptions, such as errors originating from node core libraries, like network errors, and operational errors which are instances of FetchError. See the [error handling document](ERROR-HANDLING.md)  for more details.
+Adding a catch to the fetch promise chain will catch *all* exceptions, such as errors originating from node core libraries, network errors and operational errors, which are instances of FetchError. See the [error handling document](ERROR-HANDLING.md)  for more details.
 
 ```js
 fetch('https://domain.invalid/')
@@ -186,7 +189,7 @@ fetch('https://assets-cdn.github.com/images/modules/logos_page/Octocat.png')
 ```
 
 #### Buffer
-If you prefer to cache binary data in full, use buffer(). (NOTE: buffer() is a `node-fetch` only API)
+If you prefer to cache binary data in full, use buffer(). (NOTE: `buffer()` is a `node-fetch`-only API)
 
 ```js
 const fileType = require('file-type');
@@ -211,7 +214,7 @@ fetch('https://github.com/')
 
 #### Extract Set-Cookie Header
 
-Unlike browsers, you can access raw `Set-Cookie` headers manually using `Headers.raw()`, this is a `node-fetch` only API.
+Unlike browsers, you can access raw `Set-Cookie` headers manually using `Headers.raw()`. This is a `node-fetch` only API.
 
 ```js
 fetch(url).then(res => {
@@ -263,11 +266,11 @@ fetch('https://httpbin.org/post', options)
 
 #### Request cancellation with AbortSignal
 
-> NOTE: You may only cancel streamed requests on Node >= v8.0.0
+> NOTE: You may cancel streamed requests only on Node >= v8.0.0
 
 You may cancel requests with `AbortController`. A suggested implementation is [`abort-controller`](https://www.npmjs.com/package/abort-controller).
 
-An example of timing out a request after 150ms could be achieved as follows:
+An example of timing out a request after 150ms could be achieved as the following:
 
 ```js
 import AbortController from 'abort-controller';
@@ -308,7 +311,7 @@ See [test cases](https://github.com/bitinn/node-fetch/blob/master/test/test.js) 
 
 Perform an HTTP(S) fetch.
 
-`url` should be an absolute url, such as `https://example.com/`. A path-relative URL (`/file/under/root`) or protocol-relative URL (`//can-be-http-or-https.com/`) will result in a rejected promise.
+`url` should be an absolute url, such as `https://example.com/`. A path-relative URL (`/file/under/root`) or protocol-relative URL (`//can-be-http-or-https.com/`) will result in a rejected `Promise`.
 
 <a id="fetch-options"></a>
 ### Options
@@ -350,7 +353,7 @@ Note: when `body` is a `Stream`, `Content-Length` is not set automatically.
 
 ##### Custom Agent
 
-The `agent` option allows you to specify networking related options that's out of the scope of Fetch. Including and not limit to:
+The `agent` option allows you to specify networking related options which are out of the scope of Fetch, including and not limited to the following:
 
 - Support self-signed certificate
 - Use only IPv4 or IPv6
@@ -358,7 +361,7 @@ The `agent` option allows you to specify networking related options that's out o
 
 See [`http.Agent`](https://nodejs.org/api/http.html#http_new_agent_options) for more information.
 
-In addition, `agent` option accepts a function that returns http(s).Agent instance given current [URL](https://nodejs.org/api/url.html), this is useful during a redirection chain across HTTP and HTTPS protocol.
+In addition, the `agent` option accepts a function that returns `http`(s)`.Agent` instance given current [URL](https://nodejs.org/api/url.html), this is useful during a redirection chain across HTTP and HTTPS protocol.
 
 ```js
 const httpAgent = new http.Agent({
@@ -432,7 +435,7 @@ The following properties are not implemented in node-fetch at this moment:
 
 <small>*(spec-compliant)*</small>
 
-- `body` A string or [Readable stream][node-readable]
+- `body` A `String` or [`Readable` stream][node-readable]
 - `options` A [`ResponseInit`][response-init] options dictionary
 
 Constructs a new `Response` object. The constructor is identical to that in the [browser](https://developer.mozilla.org/en-US/docs/Web/API/Response/Response).
@@ -462,7 +465,7 @@ This class allows manipulating and iterating over a set of HTTP headers. All met
 
 - `init` Optional argument to pre-fill the `Headers` object
 
-Construct a new `Headers` object. `init` can be either `null`, a `Headers` object, an key-value map object, or any iterable object.
+Construct a new `Headers` object. `init` can be either `null`, a `Headers` object, an key-value map object or any iterable object.
 
 ```js
 // Example adapted from https://fetch.spec.whatwg.org/#example-headers-class
@@ -503,7 +506,7 @@ The following methods are not yet implemented in node-fetch at this moment:
 
 * Node.js [`Readable` stream][node-readable]
 
-The data encapsulated in the `Body` object. Note that while the [Fetch Standard][whatwg-fetch] requires the property to always be a WHATWG `ReadableStream`, in node-fetch it is a Node.js [`Readable` stream][node-readable].
+Data are encapsulated in the `Body` object. Note that while the [Fetch Standard][whatwg-fetch] requires the property to always be a WHATWG `ReadableStream`, in node-fetch it is a Node.js [`Readable` stream][node-readable].
 
 #### body.bodyUsed
 
@@ -511,7 +514,7 @@ The data encapsulated in the `Body` object. Note that while the [Fetch Standard]
 
 * `Boolean`
 
-A boolean property for if this body has been consumed. Per spec, a consumed body cannot be used again.
+A boolean property for if this body has been consumed. Per the specs, a consumed body cannot be used again.
 
 #### body.arrayBuffer()
 #### body.blob()
@@ -538,9 +541,9 @@ Consume the body and return a promise that will resolve to a Buffer.
 
 * Returns: <code>Promise&lt;String&gt;</code>
 
-Identical to `body.text()`, except instead of always converting to UTF-8, encoding sniffing will be performed and text converted to UTF-8, if possible.
+Identical to `body.text()`, except instead of always converting to UTF-8, encoding sniffing will be performed and text converted to UTF-8 if possible.
 
-(This API requires an optional dependency on npm package [encoding](https://www.npmjs.com/package/encoding), which you need to install manually. `webpack` users may see [a warning message](https://github.com/bitinn/node-fetch/issues/412#issuecomment-379007792) due to this optional dependency.)
+(This API requires an optional dependency of the npm package [encoding](https://www.npmjs.com/package/encoding), which you need to install manually. `webpack` users may see [a warning message](https://github.com/bitinn/node-fetch/issues/412#issuecomment-379007792) due to this optional dependency.)
 
 <a id="class-fetcherror"></a>
 ### Class: FetchError
@@ -574,6 +577,10 @@ MIT
 [codecov-url]: https://codecov.io/gh/bitinn/node-fetch
 [install-size-image]: https://flat.badgen.net/packagephobia/install/node-fetch
 [install-size-url]: https://packagephobia.now.sh/result?p=node-fetch
+[discord-image]: https://img.shields.io/discord/619915844268326952?color=%237289DA&label=Discord&style=flat-square
+[discord-url]: https://discord.gg/Zxbndcm
+[opencollective-image]: https://opencollective.com/node-fetch/backers.svg
+[opencollective-url]: https://opencollective.com/node-fetch
 [whatwg-fetch]: https://fetch.spec.whatwg.org/
 [response-init]: https://fetch.spec.whatwg.org/#responseinit
 [node-readable]: https://nodejs.org/api/stream.html#stream_readable_streams

--- a/node_modules/node-fetch/browser.js
+++ b/node_modules/node-fetch/browser.js
@@ -16,7 +16,9 @@ var global = getGlobal();
 module.exports = exports = global.fetch;
 
 // Needed for TypeScript and Webpack.
-exports.default = global.fetch.bind(global);
+if (global.fetch) {
+	exports.default = global.fetch.bind(global);
+}
 
 exports.Headers = global.Headers;
 exports.Request = global.Request;

--- a/node_modules/node-fetch/lib/index.es.js
+++ b/node_modules/node-fetch/lib/index.es.js
@@ -461,6 +461,12 @@ function convertBody(buffer, headers) {
 	// html4
 	if (!res && str) {
 		res = /<meta[\s]+?http-equiv=(['"])content-type\1[\s]+?content=(['"])(.+?)\2/i.exec(str);
+		if (!res) {
+			res = /<meta[\s]+?content=(['"])(.+?)\1[\s]+?http-equiv=(['"])content-type\3/i.exec(str);
+			if (res) {
+				res.pop(); // drop last quote
+			}
+		}
 
 		if (res) {
 			res = /charset=(.*)/i.exec(res.pop());
@@ -1468,7 +1474,7 @@ function fetch(url, opts) {
 				// HTTP fetch step 5.5
 				switch (request.redirect) {
 					case 'error':
-						reject(new FetchError(`redirect mode is set to error: ${request.url}`, 'no-redirect'));
+						reject(new FetchError(`uri requested responds with a redirect, redirect mode is set to error: ${request.url}`, 'no-redirect'));
 						finalize();
 						return;
 					case 'manual':
@@ -1507,7 +1513,8 @@ function fetch(url, opts) {
 							method: request.method,
 							body: request.body,
 							signal: request.signal,
-							timeout: request.timeout
+							timeout: request.timeout,
+							size: request.size
 						};
 
 						// HTTP-redirect fetch step 9

--- a/node_modules/node-fetch/lib/index.js
+++ b/node_modules/node-fetch/lib/index.js
@@ -465,6 +465,12 @@ function convertBody(buffer, headers) {
 	// html4
 	if (!res && str) {
 		res = /<meta[\s]+?http-equiv=(['"])content-type\1[\s]+?content=(['"])(.+?)\2/i.exec(str);
+		if (!res) {
+			res = /<meta[\s]+?content=(['"])(.+?)\1[\s]+?http-equiv=(['"])content-type\3/i.exec(str);
+			if (res) {
+				res.pop(); // drop last quote
+			}
+		}
 
 		if (res) {
 			res = /charset=(.*)/i.exec(res.pop());
@@ -1472,7 +1478,7 @@ function fetch(url, opts) {
 				// HTTP fetch step 5.5
 				switch (request.redirect) {
 					case 'error':
-						reject(new FetchError(`redirect mode is set to error: ${request.url}`, 'no-redirect'));
+						reject(new FetchError(`uri requested responds with a redirect, redirect mode is set to error: ${request.url}`, 'no-redirect'));
 						finalize();
 						return;
 					case 'manual':
@@ -1511,7 +1517,8 @@ function fetch(url, opts) {
 							method: request.method,
 							body: request.body,
 							signal: request.signal,
-							timeout: request.timeout
+							timeout: request.timeout,
+							size: request.size
 						};
 
 						// HTTP-redirect fetch step 9

--- a/node_modules/node-fetch/lib/index.mjs
+++ b/node_modules/node-fetch/lib/index.mjs
@@ -459,6 +459,12 @@ function convertBody(buffer, headers) {
 	// html4
 	if (!res && str) {
 		res = /<meta[\s]+?http-equiv=(['"])content-type\1[\s]+?content=(['"])(.+?)\2/i.exec(str);
+		if (!res) {
+			res = /<meta[\s]+?content=(['"])(.+?)\1[\s]+?http-equiv=(['"])content-type\3/i.exec(str);
+			if (res) {
+				res.pop(); // drop last quote
+			}
+		}
 
 		if (res) {
 			res = /charset=(.*)/i.exec(res.pop());
@@ -1466,7 +1472,7 @@ function fetch(url, opts) {
 				// HTTP fetch step 5.5
 				switch (request.redirect) {
 					case 'error':
-						reject(new FetchError(`redirect mode is set to error: ${request.url}`, 'no-redirect'));
+						reject(new FetchError(`uri requested responds with a redirect, redirect mode is set to error: ${request.url}`, 'no-redirect'));
 						finalize();
 						return;
 					case 'manual':
@@ -1505,7 +1511,8 @@ function fetch(url, opts) {
 							method: request.method,
 							body: request.body,
 							signal: request.signal,
-							timeout: request.timeout
+							timeout: request.timeout,
+							size: request.size
 						};
 
 						// HTTP-redirect fetch step 9

--- a/node_modules/node-fetch/package.json
+++ b/node_modules/node-fetch/package.json
@@ -1,27 +1,32 @@
 {
-  "_from": "node-fetch@^2.3.0",
-  "_id": "node-fetch@2.6.0",
+  "_args": [
+    [
+      "node-fetch@2.6.1",
+      "C:\\Users\\boswe\\NodeProjects\\upload-google-play"
+    ]
+  ],
+  "_from": "node-fetch@2.6.1",
+  "_id": "node-fetch@2.6.1",
   "_inBundle": false,
-  "_integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+  "_integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
   "_location": "/node-fetch",
   "_phantomChildren": {},
   "_requested": {
-    "type": "range",
+    "type": "version",
     "registry": true,
-    "raw": "node-fetch@^2.3.0",
+    "raw": "node-fetch@2.6.1",
     "name": "node-fetch",
     "escapedName": "node-fetch",
-    "rawSpec": "^2.3.0",
+    "rawSpec": "2.6.1",
     "saveSpec": null,
-    "fetchSpec": "^2.3.0"
+    "fetchSpec": "2.6.1"
   },
   "_requiredBy": [
     "/gaxios"
   ],
-  "_resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-  "_shasum": "e633456386d4aa55863f676a7ab0daa8fdecb0fd",
-  "_spec": "node-fetch@^2.3.0",
-  "_where": "/Users/drew.heavner/Documents/Github/upload-google-play/node_modules/gaxios",
+  "_resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+  "_spec": "2.6.1",
+  "_where": "C:\\Users\\boswe\\NodeProjects\\upload-google-play",
   "author": {
     "name": "David Frank"
   },
@@ -29,9 +34,7 @@
   "bugs": {
     "url": "https://github.com/bitinn/node-fetch/issues"
   },
-  "bundleDependencies": false,
   "dependencies": {},
-  "deprecated": false,
   "description": "A light-weight module that brings window.fetch to node.js",
   "devDependencies": {
     "@ungap/url-search-params": "^0.1.2",
@@ -89,5 +92,5 @@
     "report": "cross-env BABEL_ENV=coverage nyc --reporter lcov --reporter text mocha -R spec test/test.js",
     "test": "cross-env BABEL_ENV=test mocha --require babel-register --throw-deprecation test/test.js"
   },
-  "version": "2.6.0"
+  "version": "2.6.1"
 }

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -44,13 +44,13 @@ export async function uploadToPlayStore(options: EditOptions, releaseFiles: stri
             auth: options.auth,
             packageName: options.applicationId
         });
-        
+
         // Validate the given track
         await validateSelectedTrack(appEdit.data, options).catch(reason => {
             core.setFailed(reason);
             return Promise.reject(reason);
         });
-    
+
         // Upload artifacts to Google Play, and store their version codes
         var versionCodes = new Array<number>();
         for (const releaseFile in releaseFiles) {
@@ -61,7 +61,7 @@ export async function uploadToPlayStore(options: EditOptions, releaseFiles: stri
             });
             versionCodes.push(versionCode!);
         }
-        
+
         // Add the uploaded artifacts to the Edit track
         const track = await addReleasesToTrack(appEdit.data, options, versionCodes);
 
@@ -71,7 +71,7 @@ export async function uploadToPlayStore(options: EditOptions, releaseFiles: stri
             editId: appEdit.data.id!,
             packageName: options.applicationId
         });
-    
+
         // Simple check to see whether commit was successful
         if (res.data.id != null) {
             core.debug(`Successfully committed ${res.data.id}`);

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -93,7 +93,6 @@ async function uploadInternalSharingRelease(options: EditOptions, releaseFile: s
         console.log(`${releaseFile} uploaded to Internal Sharing, download it with ${res.downloadUrl}`)
         return Promise.resolve(res.downloadUrl)
     } else {
-        core.setFailed(`${releaseFile} is invalid`)
         return Promise.reject(`${releaseFile} is invalid`)
     }
 }
@@ -108,7 +107,6 @@ async function uploadRelease(appEdit: AppEdit, options: EditOptions, releaseFile
         await uploadMappingFile(appEdit, bundle.versionCode!, options);
         return Promise.resolve(bundle.versionCode);
     } else {
-        core.setFailed(`${releaseFile} is invalid`);
         return Promise.reject(`${releaseFile} is invalid`);
     }
 }
@@ -121,8 +119,7 @@ async function validateSelectedTrack(appEdit: AppEdit, options: EditOptions): Pr
     });
     const allTracks = res.data.tracks;
     if (allTracks == undefined || allTracks.find(value => value.track == options.track) == undefined) {
-        core.setFailed(`Track "${options.track}" could not be found `);
-        return Promise.reject(`No track found for "${options.track}"`);
+        return Promise.reject(`Track "${options.track}" could not be found `);
     }
 }
 
@@ -148,7 +145,7 @@ async function addReleasesToTrack(appEdit: AppEdit, options: EditOptions, versio
                         userFraction: options.userFraction,
                         status: status,
                         releaseNotes: await readLocalizedReleaseNotes(options.whatsNewDir),
-                        versionCodes: versionCodes.map(x => x.toString())
+                        versionCodes: versionCodes.filter(x => x != 0).map(x => x.toString())
                     }
                 ]
             }

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -28,89 +28,106 @@ export interface EditOptions {
 }
 
 export async function uploadToPlayStore(options: EditOptions, releaseFiles: string[]): Promise<string | undefined> {
-    const appEdit = await androidPublisher.edits.insert({
-        auth: options.auth,
-        packageName: options.applicationId
-    });
-    
-    releaseFiles.forEach(async releaseFile => {
-        core.debug(`Uploading ${releaseFile}`)
-        await uploadRelease(appEdit.data, options, releaseFile).catch(reason => {
-            return Promise.reject(reason)
-        })
-    })
-
-    const res = await androidPublisher.edits.commit({
-        auth: options.auth,
-        editId: appEdit.data.id!,
-        packageName: options.applicationId
-    });
-
-    if (res.data.id != null) {
-        core.debug(`Successfully committed ${res.data.id}`)
-        return Promise.resolve(res.data.id!)
+    if (options.track === 'internalappsharing') {
+        core.debug("Track is Internal app sharing, switch to special upload api")
+        releaseFiles.forEach(async releaseFile => {
+            core.debug(`Uploading ${releaseFile}`);
+            await uploadInternalSharingRelease(options, releaseFile).catch(reason => {
+                core.setFailed(reason);
+                return Promise.reject(reason);
+            });
+        });
     } else {
-        core.setFailed(`Error ${res.status}: ${res.statusText}`)
-        return Promise.reject(res.status)
+        const appEdit = await androidPublisher.edits.insert({
+            auth: options.auth,
+            packageName: options.applicationId
+        });
+        
+        await validateSelectedTrack(appEdit.data, options).catch(reason => {
+            core.setFailed(reason);
+            return Promise.reject(reason);
+        });
+    
+        // Check the 'track' for 'internalsharing', if so switch to a non-track api
+        var versionCodes = new Array<number>();
+        releaseFiles.forEach(async releaseFile => {
+            core.debug(`Uploading ${releaseFile}`);
+            const versionCode = await uploadRelease(appEdit.data, options, releaseFile).catch(reason => {
+                core.setFailed(reason);
+                return Promise.reject(reason);
+            });
+            versionCodes.push(versionCode!);
+        });
+        
+        const track = addReleasesToTrack(appEdit.data, options, versionCodes);
+        const res = await androidPublisher.edits.commit({
+            auth: options.auth,
+            editId: appEdit.data.id!,
+            packageName: options.applicationId
+        });
+    
+        if (res.data.id != null) {
+            core.debug(`Successfully committed ${res.data.id}`);
+            return Promise.resolve(res.data.id!);
+        } else {
+            core.setFailed(`Error ${res.status}: ${res.statusText}`);
+            return Promise.reject(res.status);
+        }
     }
 }
 
-async function uploadRelease(appEdit: AppEdit, options: EditOptions, releaseFile: string): Promise<string | undefined | null> {
-    // Check the 'track' for 'internalsharing', if so switch to a non-track api
-    if (options.track === 'internalsharing'){
-        core.debug("Track is Internal app sharing, switch to special upload api")
-        if (releaseFile.endsWith('.apk')) {
-            const res = await internalSharingUploadApk(options, releaseFile)
-            return Promise.resolve(res.downloadUrl)
-        } else if (releaseFile.endsWith('.aab')) {
-            const res = await internalSharingUploadBundle(options, releaseFile)
-            return Promise.resolve(res.downloadUrl)
-        } else {
-            core.setFailed(`${releaseFile} is invalid`)
-            return Promise.reject(`${releaseFile} is invalid`)
-        }
-    }
-
-    const allTracks = await getAllTracks(appEdit!, options);
-    if (allTracks == undefined || allTracks.find(value => value.track == options.track) == undefined) {
-        core.setFailed(`Track "${options.track}" could not be found `)
-        return Promise.reject(`No track found for "${options.track}"`)
-    }
-
-    let track: Track | undefined = undefined;
+async function uploadInternalSharingRelease(options: EditOptions, releaseFile: string): Promise<string | undefined | null> {
     if (releaseFile.endsWith('.apk')) {
-        const apk = await uploadApk(appEdit, options, releaseFile);
-        await uploadMappingFile(appEdit, apk.versionCode!, options);
-        track = await trackVersionCode(appEdit, options, apk.versionCode!)
+        const res = await internalSharingUploadApk(options, releaseFile)
+        console.log(`${releaseFile} uploaded to Internal Sharing, download it with ${res.downloadUrl}`)
+        return Promise.resolve(res.downloadUrl)
     } else if (releaseFile.endsWith('.aab')) {
-        const bundle = await uploadBundle(appEdit, options, releaseFile);
-        await uploadMappingFile(appEdit, bundle.versionCode!, options);
-        track = await trackVersionCode(appEdit, options, bundle.versionCode!)
+        const res = await internalSharingUploadBundle(options, releaseFile)
+        console.log(`${releaseFile} uploaded to Internal Sharing, download it with ${res.downloadUrl}`)
+        return Promise.resolve(res.downloadUrl)
     } else {
         core.setFailed(`${releaseFile} is invalid`)
         return Promise.reject(`${releaseFile} is invalid`)
     }
 }
 
-async function getAllTracks(appEdit: AppEdit, options: EditOptions): Promise<Track[] | undefined> {
+async function uploadRelease(appEdit: AppEdit, options: EditOptions, releaseFile: string): Promise<number | undefined | null> {
+    if (releaseFile.endsWith('.apk')) {
+        const apk = await uploadApk(appEdit, options, releaseFile);
+        await uploadMappingFile(appEdit, apk.versionCode!, options);
+        return Promise.resolve(apk.versionCode);
+    } else if (releaseFile.endsWith('.aab')) {
+        const bundle = await uploadBundle(appEdit, options, releaseFile);
+        await uploadMappingFile(appEdit, bundle.versionCode!, options);
+        return Promise.resolve(bundle.versionCode);
+    } else {
+        core.setFailed(`${releaseFile} is invalid`);
+        return Promise.reject(`${releaseFile} is invalid`);
+    }
+}
+
+async function validateSelectedTrack(appEdit: AppEdit, options: EditOptions): Promise<undefined> {
     const res = await androidPublisher.edits.tracks.list({
         auth: options.auth,
         editId: appEdit.id!,
         packageName: options.applicationId
     });
-
-    return res.data.tracks
+    const allTracks = res.data.tracks;
+    if (allTracks == undefined || allTracks.find(value => value.track == options.track) == undefined) {
+        core.setFailed(`Track "${options.track}" could not be found `);
+        return Promise.reject(`No track found for "${options.track}"`);
+    }
 }
 
-async function trackVersionCode(appEdit: AppEdit, options: EditOptions, versionCode: number): Promise<Track> {
+async function addReleasesToTrack(appEdit: AppEdit, options: EditOptions, versionCodes: number[]): Promise<Track> {
     let status: string;
     if (options.userFraction != undefined) {
-        status = 'inProgress'
+        status = 'inProgress';
     } else {
-        status = 'completed'
+        status = 'completed';
     }
 
-    core.debug(`Creating Track Release for Edit(${appEdit.id}) for Track(${options.track}) with a UserFraction(${options.userFraction}) and VersionCode(${versionCode})`);
+    core.debug(`Creating Track Release for Edit(${appEdit.id}) for Track(${options.track}) with a UserFraction(${options.userFraction}) and VersionCodes(${versionCodes})`);
     const res = await androidPublisher.edits.tracks
         .update({
             auth: options.auth,
@@ -124,15 +141,13 @@ async function trackVersionCode(appEdit: AppEdit, options: EditOptions, versionC
                         userFraction: options.userFraction,
                         status: status,
                         releaseNotes: await readLocalizedReleaseNotes(options.whatsNewDir),
-                        versionCodes: [
-                            versionCode.toString()
-                        ]
+                        versionCodes: versionCodes.map(x => x.toString())
                     }
                 ]
             }
         });
 
-    return res.data
+    return res.data;
 }
 
 async function uploadMappingFile(appEdit: AppEdit, versionCode: number, options: EditOptions) {

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -31,13 +31,13 @@ export async function uploadToPlayStore(options: EditOptions, releaseFiles: stri
     // Check the 'track' for 'internalsharing', if so switch to a non-track api
     if (options.track === 'internalsharing') {
         core.debug("Track is Internal app sharing, switch to special upload api")
-        releaseFiles.forEach(async releaseFile => {
+        for (const releaseFile in releaseFiles) {
             core.debug(`Uploading ${releaseFile}`);
             await uploadInternalSharingRelease(options, releaseFile).catch(reason => {
                 core.setFailed(reason);
                 return Promise.reject(reason);
             });
-        });
+        }
     } else {
         // Create a new Edit
         const appEdit = await androidPublisher.edits.insert({
@@ -53,14 +53,14 @@ export async function uploadToPlayStore(options: EditOptions, releaseFiles: stri
     
         // Upload artifacts to Google Play, and store their version codes
         var versionCodes = new Array<number>();
-        releaseFiles.forEach(async releaseFile => {
+        for (const releaseFile in releaseFiles) {
             core.debug(`Uploading ${releaseFile}`);
             const versionCode = await uploadRelease(appEdit.data, options, releaseFile).catch(reason => {
                 core.setFailed(reason);
                 return Promise.reject(reason);
             });
             versionCodes.push(versionCode!);
-        });
+        }
         
         // Add the uploaded artifacts to the Edit track
         const track = addReleasesToTrack(appEdit.data, options, versionCodes);

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -29,7 +29,7 @@ export interface EditOptions {
 
 export async function uploadToPlayStore(options: EditOptions, releaseFiles: string[]): Promise<string | undefined> {
     // Check the 'track' for 'internalsharing', if so switch to a non-track api
-    if (options.track === 'internalappsharing') {
+    if (options.track === 'internalsharing') {
         core.debug("Track is Internal app sharing, switch to special upload api")
         releaseFiles.forEach(async releaseFile => {
             core.debug(`Uploading ${releaseFile}`);

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -63,7 +63,7 @@ export async function uploadToPlayStore(options: EditOptions, releaseFiles: stri
         }
         
         // Add the uploaded artifacts to the Edit track
-        const track = addReleasesToTrack(appEdit.data, options, versionCodes);
+        const track = await addReleasesToTrack(appEdit.data, options, versionCodes);
 
         // Commit the pending Edit
         const res = await androidPublisher.edits.commit({

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -31,7 +31,7 @@ export async function uploadToPlayStore(options: EditOptions, releaseFiles: stri
     // Check the 'track' for 'internalsharing', if so switch to a non-track api
     if (options.track === 'internalsharing') {
         core.debug("Track is Internal app sharing, switch to special upload api")
-        for (const releaseFile in releaseFiles) {
+        for (const releaseFile of releaseFiles) {
             core.debug(`Uploading ${releaseFile}`);
             await uploadInternalSharingRelease(options, releaseFile).catch(reason => {
                 core.setFailed(reason);
@@ -53,7 +53,7 @@ export async function uploadToPlayStore(options: EditOptions, releaseFiles: stri
 
         // Upload artifacts to Google Play, and store their version codes
         var versionCodes = new Array<number>();
-        for (const releaseFile in releaseFiles) {
+        for (const releaseFile of releaseFiles) {
             core.debug(`Uploading ${releaseFile}`);
             const versionCode = await uploadRelease(appEdit.data, options, releaseFile).catch(reason => {
                 core.setFailed(reason);

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,6 +52,7 @@ async function run() {
         }
 
         // Check release files
+        console.log(`Checking ${releaseFiles.length} files`)
         releaseFiles.forEach(releaseFile => {
             if (!fs.existsSync(releaseFile)) {
                 core.setFailed(`Unable to find release file @ ${releaseFile}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ async function run() {
         const serviceAccountJson = core.getInput('serviceAccountJson', { required: false });
         const serviceAccountJsonRaw = core.getInput('serviceAccountJsonPlainText', { required: false});
         const packageName = core.getInput('packageName', { required: true });
-        const releaseFiles = core.getInput('releaseFile', { required: true }).split(',').filter(x => x !== '');
+        const releaseFiles = core.getInput('releaseFiles', { required: true }).split(',').filter(x => x !== '');
         const track = core.getInput('track', { required: true });
         const userFraction = core.getInput('userFraction', { required: false });
         const whatsNewDir = core.getInput('whatsNewDirectory', { required: false });

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,6 +52,7 @@ async function run() {
         }
 
         // Check release files
+        core.debug(`Checking release files ${releaseFiles}`);
         for (const releaseFile in releaseFiles) {
             if (!fs.existsSync(releaseFile)) {
                 core.setFailed(`Unable to find release file @ ${releaseFile}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ async function run() {
         const serviceAccountJson = core.getInput('serviceAccountJson', { required: false });
         const serviceAccountJsonRaw = core.getInput('serviceAccountJsonPlainText', { required: false});
         const packageName = core.getInput('packageName', { required: true });
-        const releaseFile = core.getInput('releaseFile', { required: true });
+        const releaseFiles = core.getInput('releaseFile', { required: true }).split("|").filter(x => x !== "");
         const track = core.getInput('track', { required: true });
         const userFraction = core.getInput('userFraction', { required: false });
         const whatsNewDir = core.getInput('whatsNewDirectory', { required: false });
@@ -51,11 +51,13 @@ async function run() {
             userFractionFloat = undefined
         }
 
-        // Check release file
-        if (!fs.existsSync(releaseFile)) {
-            core.setFailed(`Unable to find release file @ ${releaseFile}`);
-            return
-        }
+        // Check release files
+        releaseFiles.forEach(releaseFile => {
+            if (!fs.existsSync(releaseFile)) {
+                core.setFailed(`Unable to find release file @ ${releaseFile}`);
+                return
+            }
+        });
 
         if (whatsNewDir != undefined && whatsNewDir.length > 0 && !fs.existsSync(whatsNewDir)) {
             core.setFailed(`Unable to find 'whatsnew' directory @ ${whatsNewDir}`);
@@ -76,14 +78,14 @@ async function run() {
             userFraction: userFractionFloat,
             whatsNewDir: whatsNewDir,
             mappingFile: mappingFile
-        }, releaseFile);
+        }, releaseFiles);
 
         if (downloadUrl) {
             core.setOutput('internalSharingDownloadUrl', downloadUrl);
             core.exportVariable('INTERNAL_SHARING_DOWNLOAD_URL', downloadUrl);
         }
 
-        console.log(`Finished uploading ${releaseFile} to the Play Store`)
+        console.log(`Finished uploading to the Play Store`)
     } catch (error) {
         core.setFailed(error.message)
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,7 +52,6 @@ async function run() {
         }
 
         // Check release files
-        console.log(`Checking ${releaseFiles.length} files`)
         releaseFiles.forEach(releaseFile => {
             if (!fs.existsSync(releaseFile)) {
                 core.setFailed(`Unable to find release file @ ${releaseFile}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,7 +71,7 @@ async function run() {
 
         const authClient = await auth.getClient();
 
-        const downloadUrl = await uploadToPlayStore({
+        await uploadToPlayStore({
             auth: authClient,
             applicationId: packageName,
             track: track,
@@ -79,11 +79,6 @@ async function run() {
             whatsNewDir: whatsNewDir,
             mappingFile: mappingFile
         }, releaseFiles);
-
-        if (downloadUrl) {
-            core.setOutput('internalSharingDownloadUrl', downloadUrl);
-            core.exportVariable('INTERNAL_SHARING_DOWNLOAD_URL', downloadUrl);
-        }
 
         console.log(`Finished uploading to the Play Store`)
     } catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,12 +52,12 @@ async function run() {
         }
 
         // Check release files
-        releaseFiles.forEach(releaseFile => {
+        for (const releaseFile in releaseFiles) {
             if (!fs.existsSync(releaseFile)) {
                 core.setFailed(`Unable to find release file @ ${releaseFile}`);
                 return
             }
-        });
+        }
 
         if (whatsNewDir != undefined && whatsNewDir.length > 0 && !fs.existsSync(whatsNewDir)) {
             core.setFailed(`Unable to find 'whatsnew' directory @ ${whatsNewDir}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 import * as fs from "fs";
-import {uploadRelease} from "./edits";
+import { uploadToPlayStore } from "./edits";
 const {google} = require('googleapis');
 
 const auth = new google.auth.GoogleAuth({
@@ -71,7 +71,7 @@ async function run() {
 
         const authClient = await auth.getClient();
 
-        const downloadUrl = await uploadRelease({
+        const downloadUrl = await uploadToPlayStore({
             auth: authClient,
             applicationId: packageName,
             track: track,

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,8 +52,7 @@ async function run() {
         }
 
         // Check release files
-        core.debug(`Checking release files ${releaseFiles}`);
-        for (const releaseFile in releaseFiles) {
+        for (const releaseFile of releaseFiles) {
             core.debug(`Validating ${releaseFile} exists`)
             if (!fs.existsSync(releaseFile)) {
                 core.setFailed(`Unable to find release file @ ${releaseFile}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,6 +54,7 @@ async function run() {
         // Check release files
         core.debug(`Checking release files ${releaseFiles}`);
         for (const releaseFile in releaseFiles) {
+            core.debug(`Validating ${releaseFile} exists`)
             if (!fs.existsSync(releaseFile)) {
                 core.setFailed(`Unable to find release file @ ${releaseFile}`);
                 return

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ async function run() {
         const serviceAccountJson = core.getInput('serviceAccountJson', { required: false });
         const serviceAccountJsonRaw = core.getInput('serviceAccountJsonPlainText', { required: false});
         const packageName = core.getInput('packageName', { required: true });
-        const releaseFiles = core.getInput('releaseFile', { required: true }).split("|").filter(x => x !== "");
+        const releaseFiles = core.getInput('releaseFile', { required: true }).split(',').filter(x => x !== '');
         const track = core.getInput('track', { required: true });
         const userFraction = core.getInput('userFraction', { required: false });
         const whatsNewDir = core.getInput('whatsNewDirectory', { required: false });


### PR DESCRIPTION
Useful for projects that target multiple platforms (Wear OS, Android TV, Android phones etc).
Needs more testing, but I've been using these changes for one of my projects and uploading 2 artifacts at a time seems to work fine.