### PR TITLE
Output published release name on success

### DIFF
--- a/lib/edits.js
+++ b/lib/edits.js
@@ -14,7 +14,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
@@ -80,6 +80,7 @@ function uploadToPlayStore(options, releaseFiles) {
             // Simple check to see whether commit was successful
             if (res.data.id != null) {
                 core.debug(`Successfully committed ${res.data.id}`);
+                core.setOutput("releaseName", getPublishedReleaseName(res.data, options));
                 return Promise.resolve(res.data.id);
             }
             else {
@@ -247,5 +248,15 @@ function uploadBundle(appEdit, options, bundleReleaseFile) {
             }
         });
         return res.data;
+    });
+}
+function getPublishedReleaseName(appEdit, options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const track = yield androidPublisher.edits.tracks.get({
+            editId: appEdit.id,
+            track: options.track
+        });
+        const release = track.data.releases[0]; // We only ever create one release, so grab the first one
+        return release.name;
     });
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -14,7 +14,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };

--- a/lib/whatsnew.js
+++ b/lib/whatsnew.js
@@ -14,7 +14,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -77,6 +77,7 @@ export async function uploadToPlayStore(options: EditOptions, releaseFiles: stri
         // Simple check to see whether commit was successful
         if (res.data.id != null) {
             core.debug(`Successfully committed ${res.data.id}`);
+            core.setOutput("releaseName", getPublishedReleaseName(res.data, options))
             return Promise.resolve(res.data.id!);
         } else {
             core.setFailed(`Error ${res.status}: ${res.statusText}`);
@@ -237,4 +238,13 @@ async function uploadBundle(appEdit: AppEdit, options: EditOptions, bundleReleas
     });
 
     return res.data
+}
+
+async function getPublishedReleaseName(appEdit: AppEdit, options: EditOptions): Promise<String | null | undefined> {
+    const track = await androidPublisher.edits.tracks.get({
+        editId: appEdit.id!,
+        track: options.track
+    })
+    const release = track.data.releases![0] // We only ever create one release, so grab the first one
+    return release.name
 }


### PR DESCRIPTION
Resolves #42 
Helpful if you still want Google Play to generate a release name based on the app's version name and still need the output.