### PR TITLE
Name output improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ The mapping.txt file used to de-obfuscate your stack traces from crash reports
 
 ## Outputs
 
+### `releaseName`
+
+The name of the release published to Google Play, which is generated on commit by default
+
 ### `internalSharingDownloadUrl`
 
 The download url for an app that was uploaded using the `track` `internalsharing`

--- a/lib/edits.js
+++ b/lib/edits.js
@@ -80,7 +80,8 @@ function uploadToPlayStore(options, releaseFiles) {
             // Simple check to see whether commit was successful
             if (res.data.id != null) {
                 core.debug(`Successfully committed ${res.data.id}`);
-                core.setOutput("releaseName", getPublishedReleaseName(res.data, options));
+                const name = options.name || getPublishedReleaseName(res.data, options);
+                core.setOutput("releaseName", name);
                 return Promise.resolve(res.data.id);
             }
             else {

--- a/lib/edits.js
+++ b/lib/edits.js
@@ -80,7 +80,7 @@ function uploadToPlayStore(options, releaseFiles) {
             // Simple check to see whether commit was successful
             if (res.data.id != null) {
                 core.debug(`Successfully committed ${res.data.id}`);
-                const name = options.name || getPublishedReleaseName(res.data, options);
+                const name = options.name || (yield getPublishedReleaseName(res.data, options));
                 core.setOutput("releaseName", name);
                 return Promise.resolve(res.data.id);
             }

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -77,7 +77,7 @@ export async function uploadToPlayStore(options: EditOptions, releaseFiles: stri
         // Simple check to see whether commit was successful
         if (res.data.id != null) {
             core.debug(`Successfully committed ${res.data.id}`);
-            const name = options.name || getPublishedReleaseName(res.data, options);
+            const name = options.name || (await getPublishedReleaseName(res.data, options));
             core.setOutput("releaseName", name)
             return Promise.resolve(res.data.id!);
         } else {

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -77,7 +77,8 @@ export async function uploadToPlayStore(options: EditOptions, releaseFiles: stri
         // Simple check to see whether commit was successful
         if (res.data.id != null) {
             core.debug(`Successfully committed ${res.data.id}`);
-            core.setOutput("releaseName", getPublishedReleaseName(res.data, options))
+            const name = options.name || getPublishedReleaseName(res.data, options);
+            core.setOutput("releaseName", name)
             return Promise.resolve(res.data.id!);
         } else {
             core.setFailed(`Error ${res.status}: ${res.statusText}`);


### PR DESCRIPTION
Added the output to the readme, fixed an issue caused by not awaiting the promise, and optimized performance when a release name is provided.