### PR TITLE
Fix release name output being undefined

### DIFF
--- a/lib/edits.js
+++ b/lib/edits.js
@@ -79,7 +79,12 @@ function uploadToPlayStore(options, releaseFiles) {
             // Extract the release name for the response
             let trackReleaseName;
             if (track.releases && track.releases.length > 0) {
-                const trackRelease = track.releases[0];
+                const tracks = yield androidPublisher.edits.tracks.list({
+                    auth: options.auth,
+                    editId: appEdit.data.id,
+                    packageName: options.applicationId
+                });
+                const trackRelease = tracks.data.tracks[0].releases[0];
                 trackReleaseName = trackRelease.name;
                 core.debug(`Pulled track release name from update: ${trackReleaseName}`);
             }

--- a/lib/edits.js
+++ b/lib/edits.js
@@ -79,12 +79,8 @@ function uploadToPlayStore(options, releaseFiles) {
             // Extract the release name for the response
             let trackReleaseName;
             if (track.releases && track.releases.length > 0) {
-                const tracks = yield androidPublisher.edits.tracks.list({
-                    auth: options.auth,
-                    editId: appEdit.data.id,
-                    packageName: options.applicationId
-                });
-                const trackRelease = tracks.data.tracks[0].releases[0];
+                const track = yield getTrackData(appEdit.data, options);
+                const trackRelease = track.releases[0];
                 trackReleaseName = trackRelease.name;
                 core.debug(`Pulled track release name from update: ${trackReleaseName}`);
             }
@@ -276,5 +272,15 @@ function uploadBundle(appEdit, options, bundleReleaseFile) {
             }
         });
         return res.data;
+    });
+}
+function getTrackData(appEdit, options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const tracks = yield androidPublisher.edits.tracks.list({
+            auth: options.auth,
+            editId: appEdit.id,
+            packageName: options.applicationId
+        });
+        return tracks[0];
     });
 }

--- a/lib/edits.js
+++ b/lib/edits.js
@@ -281,6 +281,6 @@ function getTrackData(appEdit, options) {
             editId: appEdit.id,
             packageName: options.applicationId
         });
-        return tracks[0];
+        return tracks.data.tracks.find(value => value.track == options.track);
     });
 }

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -75,12 +75,8 @@ export async function uploadToPlayStore(options: EditOptions, releaseFiles: stri
         // Extract the release name for the response
         let trackReleaseName: string | undefined | null;
         if (track.releases && track.releases.length > 0) {
-            const tracks = await androidPublisher.edits.tracks.list({
-                auth: options.auth,
-                editId: appEdit.data.id!,
-                packageName: options.applicationId
-            })
-            const trackRelease = tracks.data.tracks![0].releases![0];
+            const track = await getTrackData(appEdit.data, options);
+            const trackRelease = track.releases![0];
             trackReleaseName = trackRelease.name;
             core.debug(`Pulled track release name from update: ${trackReleaseName}`)
         } else {
@@ -265,4 +261,14 @@ async function uploadBundle(appEdit: AppEdit, options: EditOptions, bundleReleas
     });
 
     return res.data
+}
+
+async function getTrackData(appEdit: AppEdit, options: EditOptions): Promise<androidpublisher_v3.Schema$Track> {
+    const tracks = await androidPublisher.edits.tracks.list({
+        auth: options.auth,
+        editId: appEdit.id!,
+        packageName: options.applicationId
+    });
+
+    return tracks[0];
 }

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -75,7 +75,12 @@ export async function uploadToPlayStore(options: EditOptions, releaseFiles: stri
         // Extract the release name for the response
         let trackReleaseName: string | undefined | null;
         if (track.releases && track.releases.length > 0) {
-            const trackRelease = track.releases[0];
+            const tracks = await androidPublisher.edits.tracks.list({
+                auth: options.auth,
+                editId: appEdit.data.id!,
+                packageName: options.applicationId
+            })
+            const trackRelease = tracks.data.tracks![0].releases![0];
             trackReleaseName = trackRelease.name;
             core.debug(`Pulled track release name from update: ${trackReleaseName}`)
         } else {

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -270,5 +270,5 @@ async function getTrackData(appEdit: AppEdit, options: EditOptions): Promise<and
         packageName: options.applicationId
     });
 
-    return tracks[0];
+    return tracks.data.tracks!.find(value => value.track == options.track)!;
 }


### PR DESCRIPTION
Seems like the returned track instance from edits.tracks.update only has the data we submit, so no ID and no generated release name. This means my last solution of getting the track data via id didn't work, and the previous solution would just pull undefined. Instead, this change pulls all tracks from the Edit (currently only 1 possible so no major issues) and pulls the data from that.
It's not the greatest solution IMO, but I can't seem to find any alternatives as of yet.