### PR TITLE
Add support for glob

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,17 @@ with:
   whatsNewDirectory: distribution/whatsnew
   mappingFile: app/build/outputs/mapping/release/mapping.txt
 ```
+
+Using glob to get release files
+```yaml
+uses: r0adkll/upload-google-play@v1
+with:
+  serviceAccountJson: ${{ SERVICE_ACCOUNT_JSON }}
+  packageName: com.example.MyApp
+  releaseFiles: app/build/outputs/bundle/release/*.aab
+  track: production
+  inAppUpdatePriority: 2
+  userFraction: 0.33
+  whatsNewDirectory: distribution/whatsnew
+  mappingFile: app/build/outputs/mapping/release/mapping.txt
+```

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ The service account json in plain text, provided via a secret, etc.
 **Required:** The package name, or Application Id, of the app you are uploading
 
 ### `releaseFile`
-**DEPRECATED:** Please switch to using `releaseFiles` as this will be removed in the future  
-The Android release file to upload (.apk or .aab) 
+**DEPRECATED:** Please switch to using `releaseFiles` as this will be removed in the future
+The Android release file to upload (.apk or .aab)
 
 ### `releaseFiles`
-**CAVEAT:** Either this or `releaseFile` are required  
+**CAVEAT:** Either this or `releaseFile` are required
 
-The Android release file(s) to upload (.apk or .aab). Multiple files are separated by ','.
+The Android release file(s) to upload (.apk or .aab). Multiple files are separated by ','. Supports glob.
 
 ### `releaseName`
 
@@ -33,15 +33,15 @@ The release name. Not required to be unique. If not set, the name is generated f
 
 ### `track`
 
-**Required:** The track in which you want to assign the uploaded app.  
-**Default:** `production`   
+**Required:** The track in which you want to assign the uploaded app.
+**Default:** `production`
 _Values:_ `alpha`, `beta`, `internal`, `production`, `internalsharing`
 
 ### `inAppUpdatePriority`
 
 In-app update priority of the release. All newly added APKs in the release will be considered at this priority. Can take values in the range [0, 5], with 5 the highest priority.
 
-**Default:** `0`  
+**Default:** `0`
 _Values:_ `[0, 5]`
 
 ### `userFraction`
@@ -53,7 +53,7 @@ Portion of users who should get the staged version of the app. Accepts values be
 The directory of localized whats new files to upload as the release notes. The files contained in the `whatsNewDirectory` MUST use the pattern `whatsnew-<LOCALE>` where `LOCALE` is using the [`BCP 47`](https://tools.ietf.org/html/bcp47) format, e.g.
 * `en-US` - English/America
 * `de-DE` - German/Germany
-* `ja-JP` - Japanese/Japan  
+* `ja-JP` - Japanese/Japan
 
 and contain plain `utf8` encoded text with no extension on the file. The resulting directory in your project should look something like this:
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,9 @@
-name: 'Upload Android Release to Play Store'
+name: "Upload Android Release to Play Store"
 description: "An action to upload a signed Android release (.apk or .aab) to the Google Play Store Developer Console"
-author: 'r0adkll'
+author: "r0adkll"
 branding:
-  icon: 'truck'
-  color: 'orange'
+  icon: "truck"
+  color: "orange"
 inputs:
   serviceAccountJson:
     description: "The service account json private key file to authorize the upload request"
@@ -18,18 +18,18 @@ inputs:
     description: "The Android release file to upload (.apk or .aab)"
     required: false
   releaseFiles:
-    description: "The Android release file(s) to upload (.apk or .aab). Separated by  a ',' for multiple artifacts"
+    description: "The Android release file(s) to upload (.apk or .aab). Separated by  a ',' for multiple artifacts. Supports glob"
     required: false
   releaseName:
     description: "The name of this release. If not set it's generated automatically from the APKs versionName"
     required: false
   track:
     description: "The track in which you want to assign the uploaded app."
-    default: 'production'
+    default: "production"
     required: true
   inAppUpdatePriority:
     description: "In-app update priority of the release. All newly added APKs in the release will be considered at this priority. Can take values in the range [0, 5], with 5 the highest priority. Defaults to 0."
-    default: '0'
+    default: "0"
     required: false
   userFraction:
     description: "Portion of users who should get the staged version of the app. Accepts values between 0.0 and 1.0 (exclusive-exclusive)."
@@ -44,5 +44,5 @@ outputs:
   internalSharingDownloadUrl:
     description: "The internal app sharing download url if track was 'internalsharing'"
 runs:
-  using: 'node12'
-  main: 'lib/main.js'
+  using: "node12"
+  main: "lib/main.js"

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,9 @@
-name: "Upload Android Release to Play Store"
+name: 'Upload Android Release to Play Store'
 description: "An action to upload a signed Android release (.apk or .aab) to the Google Play Store Developer Console"
-author: "r0adkll"
+author: 'r0adkll'
 branding:
-  icon: "truck"
-  color: "orange"
+  icon: 'truck'
+  color: 'orange'
 inputs:
   serviceAccountJson:
     description: "The service account json private key file to authorize the upload request"
@@ -25,11 +25,11 @@ inputs:
     required: false
   track:
     description: "The track in which you want to assign the uploaded app."
-    default: "production"
+    default: 'production'
     required: true
   inAppUpdatePriority:
     description: "In-app update priority of the release. All newly added APKs in the release will be considered at this priority. Can take values in the range [0, 5], with 5 the highest priority. Defaults to 0."
-    default: "0"
+    default: '0'
     required: false
   userFraction:
     description: "Portion of users who should get the staged version of the app. Accepts values between 0.0 and 1.0 (exclusive-exclusive)."
@@ -44,5 +44,5 @@ outputs:
   internalSharingDownloadUrl:
     description: "The internal app sharing download url if track was 'internalsharing'"
 runs:
-  using: "node12"
-  main: "lib/main.js"
+  using: 'node12'
+  main: 'lib/main.js'

--- a/lib/main.js
+++ b/lib/main.js
@@ -27,9 +27,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
 const fs = __importStar(require("fs"));
+const fast_glob_1 = __importDefault(require("fast-glob"));
 const edits_1 = require("./edits");
 const { google } = require('googleapis');
 const auth = new google.auth.GoogleAuth({
@@ -110,14 +114,13 @@ function run() {
                 }
             }
             else if (releaseFiles.length > 0) {
-                for (const file of releaseFiles) {
-                    core.debug(`Validating ${file} exists`);
-                    if (!fs.existsSync(file)) {
-                        core.setFailed(`Unable to find release file @ ${file}`);
-                        return;
-                    }
+                core.debug(`Finding files using glob ${releaseFiles}`);
+                const files = yield fast_glob_1.default(releaseFiles);
+                if (!files.length) {
+                    core.setFailed(`Unable to find any release file @ ${releaseFiles}`);
+                    return;
                 }
-                validatedReleaseFiles = releaseFiles;
+                validatedReleaseFiles = files;
             }
             if (whatsNewDir != undefined && whatsNewDir.length > 0 && !fs.existsSync(whatsNewDir)) {
                 core.setFailed(`Unable to find 'whatsnew' directory @ ${whatsNewDir}`);

--- a/lib/main.js
+++ b/lib/main.js
@@ -114,7 +114,7 @@ function run() {
                 }
             }
             else if (releaseFiles.length > 0) {
-                core.debug(`Finding files using glob ${releaseFiles}`);
+                core.debug(`Finding files ${releaseFiles}`);
                 const files = yield fast_glob_1.default(releaseFiles);
                 if (!files.length) {
                     core.setFailed(`Unable to find any release file @ ${releaseFiles}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "upload-google-play",
-  "version": "1.0.6",
+  "version": "1.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1244,6 +1244,29 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+      "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
+      "requires": {
+        "@nodelib/fs.stat": "2.0.4",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+      "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q=="
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+      "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.4",
+        "fastq": "^1.6.0"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
@@ -1828,7 +1851,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -2603,6 +2625,19 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "fast-glob": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2620,6 +2655,14 @@
       "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
       "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
     },
+    "fastq": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
+      "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
     "fb-watchman": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -2633,7 +2676,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -2781,6 +2823,14 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "requires": {
+        "is-glob": "^4.0.1"
       }
     },
     "globals": {
@@ -3165,6 +3215,11 @@
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3177,11 +3232,18 @@
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
     },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -6156,11 +6218,15 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+    },
     "micromatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
       "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-      "dev": true,
       "requires": {
         "braces": "^3.0.1",
         "picomatch": "^2.0.5"
@@ -6540,8 +6606,7 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "pirates": {
       "version": "4.0.1",
@@ -6622,6 +6687,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
+    },
+    "queue-microtask": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
+      "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg=="
     },
     "react-is": {
       "version": "16.12.0",
@@ -6815,6 +6885,11 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -6829,6 +6904,14 @@
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -7519,7 +7602,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.4",
+    "fast-glob": "^3.2.5",
     "googleapis": "^64.0.0"
   },
   "devDependencies": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,10 +85,10 @@ async function run() {
                 validatedReleaseFiles = [releaseFile];
             }
         } else if (releaseFiles.length > 0) {
-            core.debug(`Finding files using glob ${releaseFiles}`)
+            core.debug(`Finding files ${releaseFiles.join(',')}`)
             const files = await fg(releaseFiles);
             if (!files.length) {
-                core.setFailed(`Unable to find any release file @ ${releaseFiles}`);
+                core.setFailed(`Unable to find any release file @ ${releaseFiles.join(',')}`);
                 return;
             }
             validatedReleaseFiles = files;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import * as core from '@actions/core';
 import * as fs from "fs";
+import fg from "fast-glob";
 import { uploadToPlayStore } from "./edits";
 const {google} = require('googleapis');
 
@@ -84,14 +85,13 @@ async function run() {
                 validatedReleaseFiles = [releaseFile];
             }
         } else if (releaseFiles.length > 0) {
-            for (const file of releaseFiles) {
-                core.debug(`Validating ${file} exists`)
-                if (!fs.existsSync(file)) {
-                    core.setFailed(`Unable to find release file @ ${file}`);
-                    return;
-                }
+            core.debug(`Finding files using glob ${releaseFiles}`)
+            const files = await fg(releaseFiles);
+            if (!files.length) {
+                core.setFailed(`Unable to find any release file @ ${releaseFiles}`);
+                return;
             }
-            validatedReleaseFiles = releaseFiles;
+            validatedReleaseFiles = files;
         }
 
         if (whatsNewDir != undefined && whatsNewDir.length > 0 && !fs.existsSync(whatsNewDir)) {


### PR DESCRIPTION
The releaseFiles option now supports glob using [fast-glob](https://www.npmjs.com/package/fast-glob).

Example:
```yaml
releaseFiles: ./app/build/outputs/bundle/release/*.aab
```
