### PR TITLE
Add instruction to checkout repo when using `whatsNewDirectory`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ projectDir/
 ```
 where `whatsNewDirectory` is the path you pass to the action.
 
+When providing a `whatsNewDirectory`, please ensure that the repo is checked out in a previous step. Without this step, the action will fail with error message '`Unable to find 'whatsnew' directory @ ...`'
+
+```yml
+    steps:
+
+      - name: Checkout code to get release notes
+        uses: actions/checkout@v2
+```
 
 ### `mappingFile`
 


### PR DESCRIPTION
The action failed for me when I started adding release notes. It took me a short bit to realise that it was because I was building the `aab` in a different task, so the repo source wasn't available in the task where the `upload-google-play` action was running. The solution was to add a checkout before calling the action `uses: actions/checkout@v2`.

I thought it might be a good idea to add this detail to the documentation in case someone else encounters the issue.