### PR TITLE
Fix: Support BCP 47 language codes without contry code

### DIFF
--- a/__tests__/whatsnew-ca
+++ b/__tests__/whatsnew-ca
@@ -1,0 +1,1 @@
+test_changelog_file_catalan

--- a/__tests__/whatsnew-es-ES
+++ b/__tests__/whatsnew-es-ES
@@ -1,0 +1,1 @@
+test_changelog_file_spanish

--- a/__tests__/whatsnew-et
+++ b/__tests__/whatsnew-et
@@ -1,0 +1,1 @@
+test_changelog_file_estonian

--- a/__tests__/whatsnew.test.ts
+++ b/__tests__/whatsnew.test.ts
@@ -7,7 +7,7 @@ import LocalizedText = androidpublisher_v3.Schema$LocalizedText;
 
 test("read localized whatsnew files", async () => {
     let texts = await readLocalizedReleaseNotes("./__tests__");
-    expect(texts).toHaveLength(3);
+    expect(texts).toHaveLength(6);
     expect(texts).toContainEqual({
         language: "en-US",
         text: "test_changelog_file"
@@ -19,5 +19,17 @@ test("read localized whatsnew files", async () => {
     expect(texts).toContainEqual({
         language: "ja-JP",
         text: "test_changelog_file_japanese"
+    });
+    expect(texts).toContainEqual({
+        language: "ca",
+        text: "test_changelog_file_catalan"
+    });
+    expect(texts).toContainEqual({
+        language: "es-ES",
+        text: "test_changelog_file_spanish"
+    });
+    expect(texts).toContainEqual({
+        language: "et",
+        text: "test_changelog_file_estonian"
     });
 });

--- a/src/whatsnew.ts
+++ b/src/whatsnew.ts
@@ -6,10 +6,11 @@ import {androidpublisher_v3} from "googleapis";
 import LocalizedText = androidpublisher_v3.Schema$LocalizedText;
 
 export async function readLocalizedReleaseNotes(whatsNewDir: string | undefined): Promise<LocalizedText[] | undefined> {
+    core.debug(`Executing readLocalizedReleaseNotes`);
     if (whatsNewDir != undefined && whatsNewDir.length > 0) {
         const releaseNotes = fs.readdirSync(whatsNewDir)
-            .filter(value => /whatsnew-.*-.{2,3}\b/.test(value));
-        const pattern = /whatsnew-(?<local>.*-.*)/;
+            .filter(value => /whatsnew-((.*-.*)|(.*))\b/.test(value));
+        const pattern = /whatsnew-(?<local>(.*-.*)|(.*))/;
 
         let localizedReleaseNotes: LocalizedText[] = [];
 
@@ -17,7 +18,7 @@ export async function readLocalizedReleaseNotes(whatsNewDir: string | undefined)
         releaseNotes.forEach(value => {
             const matches = value.match(pattern);
             core.debug(`Matches for ${value} = ${matches}`);
-            if (matches != undefined && matches.length == 2) {
+            if (matches != undefined && matches.length == 4) {
                 const lang = matches[1];
                 const filePath = path.join(whatsNewDir, value);
                 const content = readFileSync(filePath, 'utf-8');


### PR DESCRIPTION
Hi @r0adkll , 

Google Play Listings currently support many BCP 47 language codes without country code eg:

* et -> Estonian
* ca -> Catalan 
* ar -> Arabic

I have updated the regex filter accordingly and added new test files to support this kind of language code.

Kind Regards