### PR TITLE
Add support for explicitly specifying release status

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ _Values:_ `[0, 5]`
 
 Portion of users who should get the staged version of the app. Accepts values between 0.0 and 1.0 (exclusive-exclusive). Omitting this value will execute a full rollout.
 
+### `status`
+
+Release status. This can be set to `draft` to complete the release at some other time.
+
+**Default:** `inProgress` if `userFraction` is specified, otherwise `completed`
+
+_Values:_ `completed`, `inProgress`, `draft`, `halted`
+
 ### `whatsNewDirectory`
 
 The directory of localized whats new files to upload as the release notes. The files contained in the `whatsNewDirectory` MUST use the pattern `whatsnew-<LOCALE>` where `LOCALE` is using the [`BCP 47`](https://tools.ietf.org/html/bcp47) format, e.g.

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,9 @@ inputs:
   userFraction:
     description: "Portion of users who should get the staged version of the app. Accepts values between 0.0 and 1.0 (exclusive-exclusive)."
     required: false
+  status:
+    description: "Release status. This can be set to 'draft' to complete the release at some other time."
+    required: false
   whatsNewDirectory:
     description: "The directory of localized whats new files"
     required: false

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -27,6 +27,7 @@ export interface EditOptions {
     whatsNewDir?: string;
     mappingFile?: string;
     name?: string;
+    status?: string;
 }
 
 export async function uploadToPlayStore(options: EditOptions, releaseFiles: string[]): Promise<string | undefined> {
@@ -143,14 +144,16 @@ async function validateSelectedTrack(appEdit: AppEdit, options: EditOptions): Pr
 }
 
 async function addReleasesToTrack(appEdit: AppEdit, options: EditOptions, versionCodes: number[]): Promise<Track> {
-    let status: string;
-    if (options.userFraction != undefined) {
-        status = 'inProgress';
-    } else {
-        status = 'completed';
+    let status: string | undefined = options.status;
+    if (status == undefined) {
+        if (options.userFraction != undefined) {
+            status = 'inProgress';
+        } else {
+            status = 'completed';
+        }
     }
 
-    core.debug(`Creating Track Release for Edit(${appEdit.id}) for Track(${options.track}) with a UserFraction(${options.userFraction}) and VersionCodes(${versionCodes})`);
+    core.debug(`Creating Track Release for Edit(${appEdit.id}) for Track(${options.track}) with a UserFraction(${options.userFraction}), Status(${status}), and VersionCodes(${versionCodes})`);
     const res = await androidPublisher.edits.tracks
         .update({
             auth: options.auth,

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ async function run() {
         const track = core.getInput('track', { required: true });
         const inAppUpdatePriority = core.getInput('inAppUpdatePriority', { required: false });
         const userFraction = core.getInput('userFraction', { required: false });
+        const status = core.getInput('status', { required: false });
         const whatsNewDir = core.getInput('whatsNewDirectory', { required: false });
         const mappingFile = core.getInput('mappingFile', { required: false });
 
@@ -112,6 +113,7 @@ async function run() {
             track: track,
             inAppUpdatePriority: inAppUpdatePriorityInt || 0,
             userFraction: userFractionFloat,
+            status: status,
             whatsNewDir: whatsNewDir,
             mappingFile: mappingFile,
             name: releaseName


### PR DESCRIPTION
Addresses issues #39, #59, and #70

This is useful for cases where you don't want the app to be immediately released to the target track, but just want the aab/apk uploaded.