### PR TITLE
Fix: Clean up service-account JSON if necessary

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -120,6 +120,12 @@ async function run() {
         console.log(`Finished uploading to the Play Store: ${result}`)
     } catch (error) {
         core.setFailed(error.message)
+    } finally {
+        if (core.getInput('serviceAccountJsonPlainText', { required: false})) {
+            // Cleanup our auth file that we created.
+            core.debug('Cleaning up service account json file');
+            fs.unlinkSync('./serviceAccountJson.json');
+        }
     }
 }
 


### PR DESCRIPTION
When using `serviceAccountJsonPlainText`, the action creates a file locally containing the required data, but it was never removed. This change will remove the file once the action completes.
Closes #61 