### PR TITLE
fix: Bring back the default release status

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This action will help you upload an Android `.apk` or `.aab` (Android App Bundle
 | releaseName | The release name. Not required to be unique. Default is configured by Google Play Console | A user-friendly update name, e.g. `v1.0.0` | false |
 | inAppUpdatePriority | In-app update priority of the release. All newly added APKs in the release will be considered at this priority. Defaults to `0` | `[0-5]`, where `5` is the highest priority | false |
 | userFraction | Percentage of users who should get the staged version of the app. Defaults to `1.0` | `[0.0-1.0]` | true |
-| status | Release status. Defaults to `completed` if targeting 100% rollout, `halted` for 0%, and `inProgress` for anything in between | One of `completed`, `inProgress`, `halted`, `draft` | false |
+| status | Release status. Defaults to `completed` if targeting 100% rollout, `halted` for 0%, and `inProgress` for anything in between. Defaults to `completed` | One of `completed`, `inProgress`, `halted`, `draft` | true |
 | whatsNewDirectory | The directory of localized "whats new" files to upload as the release notes. The files contained in the `whatsNewDirectory` MUST use the pattern `whatsnew-<LOCALE>` where `LOCALE` is using the [`BCP 47`](https://tools.ietf.org/html/bcp47) format | A path to a valid `whatsNewDirectory` | false |
 | mappingFile | The mapping.txt file used to de-obfuscate your stack traces from crash reports | A path to a valid `mapping.txt` file | false |
 | debugSymbols | The native-debug-symbols.zip file or folder that contains your debug symbols | A path to a valid `native-debug-symbols.zip file` file or a folder | false |

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -8,6 +8,17 @@ async function expectRunInitiatesUpload(options: RunOptions) {
     expect(result.commands.errors).toContainEqual("The incoming JSON object does not contain a client_email field")
 }
 
+test("correct bare minimum inputs", async () => {
+    const minimumOptions = RunOptions.create()
+        .setInputs({
+            serviceAccountJsonPlainText: "{}",
+            packageName: "com.package.name",
+            releaseFiles: "./__tests__/releasefiles/*.aab",
+            track: "production",
+        })
+    await expectRunInitiatesUpload(minimumOptions)
+})
+
 test("correct inputs for complete rollout", async () => {
     // Run with the bare minimum
     const minimumOptions = RunOptions.create()
@@ -34,8 +45,8 @@ test("correct inputs for complete rollout", async () => {
             changesNotSentForReview: "true",
             existingEditId: "123"
         })
-        await expectRunInitiatesUpload(extraOptions)
-    })
+    await expectRunInitiatesUpload(extraOptions)
+})
 
 test("correct inputs for inProgress rollout", async () => {
     // Run with the bare minimum
@@ -48,7 +59,7 @@ test("correct inputs for inProgress rollout", async () => {
             userFraction: "0.99",
             status: "inProgress",
         })
-        await expectRunInitiatesUpload(minimumOptions)
+    await expectRunInitiatesUpload(minimumOptions)
 
     // Test with optional extras
     const extraOptions = RunOptions.create()
@@ -65,7 +76,7 @@ test("correct inputs for inProgress rollout", async () => {
             changesNotSentForReview: "true",
             existingEditId: "123"
         })
-        await expectRunInitiatesUpload(extraOptions)
+    await expectRunInitiatesUpload(extraOptions)
 })
 
 test("correct inputs for draft rollout", async () => {
@@ -78,7 +89,7 @@ test("correct inputs for draft rollout", async () => {
             track: "production",
             status: "draft",
         })
-        await expectRunInitiatesUpload(minimumOptions)
+    await expectRunInitiatesUpload(minimumOptions)
 
     // Test with optional extras
     const extraOptions = RunOptions.create()
@@ -94,5 +105,5 @@ test("correct inputs for draft rollout", async () => {
             changesNotSentForReview: "true",
             existingEditId: "123"
         })
-        await expectRunInitiatesUpload(extraOptions)
-    })
+    await expectRunInitiatesUpload(extraOptions)
+})

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,8 @@ inputs:
     required: false
   status:
     description: "Release status. This can be set to 'draft' to complete the release at some other time."
-    required: false
+    required: true
+    default: "completed"
   whatsNewDirectory:
     description: "The directory of localized whats new files"
     required: false


### PR DESCRIPTION
This fixes #153, a regression introduced in #142. As a temporary workaround, you can simply specify `status: "completed"`