### PR TITLE
Introduce capability to retry when upload fails, up to the given maxRetriesForUpload parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This action will help you upload an Android `.apk` or `.aab` (Android App Bundle
 | serviceAccountJson | The service account json private key file to authorize the upload request. Can be used instead of `serviceAccountJsonPlainText` to specify a file rather than provide a secret | A path to a valid `service-account.json` file | true (or serviceAccountJsonPlainText) |
 | existingEditId | The ID of an existing edit that has not been completed. If this is supplied, the action will append information to that rather than creating an edit | A valid, unpublished Edit ID | false |
 | ~~releaseFile~~ | Please switch to using `releaseFiles` as this will be removed in the future | | false |
+| maxRetriesForUpload | How many times to reattempt to upload to Google Play if an upload fails. Defaults to `0` reattempts, aside from the initial upload, but can be 0 to 99 (inclusive-inclusive) | `[0-99]` | false |
 
 ## Outputs
 
@@ -46,6 +47,7 @@ with:
   whatsNewDirectory: distribution/whatsnew
   mappingFile: app/build/outputs/mapping/release/mapping.txt
   debugSymbols: app/intermediates/merged_native_libs/release/out/lib
+  maxRetriesForUpload: 5
 ```
 
 ## FAQ

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,9 @@ inputs:
   existingEditId:
     description: "The ID of an existing edit that has not been completed. If this is supplied, the action will append information to that rather than creating an edit"
     required: false
+  maxRetriesForUpload:
+    description: "How many times to reattempt to upload to Google Play if an upload fails. Defaults to 0 reattempts, aside from the initial upload, but can be 0 to 99 (inclusive-inclusive)"
+    required: false  
 outputs:
   internalSharingDownloadUrl:
     description: "The internal app sharing download url if track was 'internalsharing'"

--- a/src/input-validation.ts
+++ b/src/input-validation.ts
@@ -43,6 +43,14 @@ export async function validateInAppUpdatePriority(inAppUpdatePriority: number | 
     }
 }
 
+export async function validateMaxRetriesForUpload(maxRetriesForUpload: number | undefined): Promise<void> {
+    if (maxRetriesForUpload) {
+        if (maxRetriesForUpload < 0 || maxRetriesForUpload > 99) {
+            return Promise.reject(new Error('maxRetriesForUpload must be between 0 and 99, inclusive-inclusive'))
+        }
+    }
+}
+
 export async function validateReleaseFiles(releaseFiles: string[] | undefined): Promise<string[]> {
     if (!releaseFiles) {
         return Promise.reject(new Error(`You must provide 'releaseFiles' in your configuration`))


### PR DESCRIPTION
This a PR to try and work around issue #188 by retrying the upload until either a success or the max retry number is reached. 

It matches the workaround of Fastlane for this issue where they simply reattempt until success or the max retry number is reached, see [here](https://github.com/fastlane/fastlane/pull/21518).