### PR TITLE
QOL: Allow userfraction of 1.0

### DIFF
--- a/src/edits.ts
+++ b/src/edits.ts
@@ -178,6 +178,12 @@ async function addReleasesToTrack(appEditId: string, options: EditOptions, versi
     core.debug(`track=${options.track}`)
     if (options.userFraction) {
         core.debug(`userFraction=${options.userFraction}`)
+
+        // When all users are targeted (i.e. userFraction equal to 1) modify it to be undfined as required by the update
+        // function provided by androidPublisher.edit.tracks
+        if (options.userFraction === 1.0) {
+            options.userFraction = undefined;
+        }
     }
     core.debug(`status=${status}`)
     core.debug(`versionCodes=${versionCodes.toString()}`)

--- a/src/input-validation.ts
+++ b/src/input-validation.ts
@@ -6,7 +6,7 @@ export async function validateUserFraction(userFraction: number | undefined): Pr
         if (isNaN(userFraction)) {
             return Promise.reject(new Error(`'userFraction' must be a number! Got ${userFraction}`))
         }
-        if (userFraction >= 1 || userFraction <= 0) {
+        if (userFraction > 1 || userFraction <= 0) {
             return Promise.reject(new Error(`'userFraction' must be between 0 and 1! Got ${userFraction}`))
         }
     }


### PR DESCRIPTION
Allows a userFraction of 1.0 to be input by a user. Anything higher than 0 is still accounted for as invalid.
Changes are currently not tested.


Another solution would be to change this at the start of the program when reading the inputs, however, that might cause confusion when debugging and the user sees the userFraction as 'undefined'.