### PR TITLE
Export commited editId for further modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This action will help you upload an Android `.apk` or `.aab` (Android App Bundle
 | --- | --- | --- |
 | internalSharingDownloadUrls | INTERNAL_SHARING_DOWNLOAD_URLS | A JSON list containing the download urls for every release file uploaded using the `internalsharing` track |
 | internalSharingDownloadUrl | INTERNAL_SHARING_DOWNLOAD_URL | The download url for the last release file uploaded using the `internalsharing` track |
+committedEditId | COMMITTED_EDIT_ID | The unique identifier of the committed edit. |
+committedEditIdExpiryTimeSeconds | COMMITTED_EDIT_ID_EXPIRY_TIME_SECONDS | Time in seconds until the committed edit expires. |
+ 
 
 ## Example usage
 

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -73,7 +73,6 @@ export async function runUpload(
 
 async function uploadToPlayStore(options: EditOptions, releaseFiles: string[]): Promise<string | void> {
     const internalSharingDownloadUrls: string[] = []
-    
     // Check the 'track' for 'internalsharing', if so switch to a non-track api
     if (options.track === 'internalsharing') {
         core.debug("Track is Internal app sharing, switch to special upload api")
@@ -115,6 +114,10 @@ async function uploadToPlayStore(options: EditOptions, releaseFiles: string[]): 
         // Simple check to see whether commit was successful
         if (res.data.id) {
             core.info(`Successfully committed ${res.data.id}`);
+		
+	    core.setOutput("uploadEditId", appEditId);
+   	    core.exportVariable("UPLOAD_EDIT_ID", appEditId);  
+		
             return res.data.id
         } else {
             core.setFailed(`Error ${res.status}: ${res.statusText}`);

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -115,8 +115,11 @@ async function uploadToPlayStore(options: EditOptions, releaseFiles: string[]): 
         if (res.data.id) {
             core.info(`Successfully committed ${res.data.id}`);
 		
-	    core.setOutput("uploadEditId", appEditId);
-   	    core.exportVariable("UPLOAD_EDIT_ID", appEditId);  
+	    core.setOutput("committedEditId", res.data.id);
+	    core.setOutput("commitedEditIdExpiryTimeSeconds", res.data.expiryTimeSeconds);
+		
+   	    core.exportVariable("COMMITED_EDIT_ID", res.data.id);  
+	    core.exportVariable("COMMITED_EDIT_ID_EXPIRY_IN_TIME_SECONDS", res.data.expiryTimeSeconds);  
 		
             return res.data.id
         } else {


### PR DESCRIPTION
Hey there!

This PR makes it easier to access important info from the release process. Right now, when a release is uploaded, we get an `edit id `as part of the response, but it’s only printed as a log message. With this update, the script will export that info as GHA outputs and environment variables, so we can easily use it in other steps if needed (without re-uploading an APK).

**Changes**:

- Exports the following outputs:

  - **committedEditId** – The unique identifier of the committed edit.

  - **committedEditIdExpiryTimeSeconds** – Time in seconds until the committed edit expires.

- Sets these values as environment variables:

  - **COMMITTED_EDIT_ID**
  - **COMMITTED_EDIT_ID_EXPIRY_TIME_SECONDS**

Now, these values are available for future steps in the workflow—making things a bit smoother! ✌️