### PR TITLE
Bumping github actions due to deprecated node-version

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Set up NPM and deps
       - name: Set up NPM
@@ -28,7 +28,7 @@ jobs:
       
       # Check whether the compiled library changed
       - name: Check Build Updated
-        uses: tj-actions/verify-changed-files@v17
+        uses: tj-actions/verify-changed-files@v18
         id: verify-built-lib
         with:
           files: lib/index.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.5.0
+    - uses: actions/checkout@v4
 
     - uses: rickstaa/action-create-tag@v1
       with:


### PR DESCRIPTION
Bumping actions due to deprecated node-version.

Example of issue in this run (and others):
https://github.com/r0adkll/upload-google-play/actions/runs/10647293252

![image](https://github.com/user-attachments/assets/468e1044-3e1b-473b-aa33-7f5c15d202a7)
