### PR TITLE
Add support for .txt whatsnew files

### DIFF
--- a/__tests__/whatsnew.test.ts
+++ b/__tests__/whatsnew.test.ts
@@ -2,7 +2,7 @@ import {readLocalizedReleaseNotes} from "../src/whatsnew";
 
 test("read localized whatsnew files", async () => {
     let texts = await readLocalizedReleaseNotes("./__tests__/whatsnew");
-    expect(texts).toHaveLength(6);
+    expect(texts).toHaveLength(7);
     expect(texts).toContainEqual({
         language: "en-US",
         text: "test_changelog_file"
@@ -26,5 +26,9 @@ test("read localized whatsnew files", async () => {
     expect(texts).toContainEqual({
         language: "et",
         text: "test_changelog_file_estonian"
+    });
+    expect(texts).toContainEqual({
+        language: "fr-FR",
+        text: "test_changelog_file_french"
     });
 });

--- a/__tests__/whatsnew/whatsnew-fr-FR.txt
+++ b/__tests__/whatsnew/whatsnew-fr-FR.txt
@@ -1,0 +1,1 @@
+test_changelog_file_french

--- a/src/whatsnew.ts
+++ b/src/whatsnew.ts
@@ -9,17 +9,17 @@ export async function readLocalizedReleaseNotes(whatsNewDir: string | undefined)
     core.debug(`Executing readLocalizedReleaseNotes`);
     if (whatsNewDir != undefined && whatsNewDir.length > 0) {
         const releaseNotes = fs.readdirSync(whatsNewDir)
-            .filter(value => /whatsnew-((.*-.*)|(.*))\b/.test(value));
-        const pattern = /whatsnew-(?<local>(.*-.*)|(.*))/;
+            .filter(value => /whatsnew-.*(\.txt)?$/.test(value));
+        const pattern = /whatsnew-(?<local>((.*-.*)|(.*?)))(\.txt)?$/;
 
         const localizedReleaseNotes: LocalizedText[] = [];
 
         core.debug(`Found files: ${releaseNotes.toString()}`);
         for (const value of releaseNotes) {
             const matches = value.match(pattern);
-            if (matches != null && matches.length == 4) {
+            if (matches && matches.groups?.local) {
                 core.debug(`Matches for ${value} = ${matches.toString()}`);
-                const lang = matches[1];
+                const lang = path.basename(value, path.extname(value)).replace(/^whatsnew-/, "");
                 const filePath = path.join(whatsNewDir, value);
                 const content = await readFile(filePath, 'utf-8');
 


### PR DESCRIPTION
  Summary 

Adds support for localized release notes files with a  .txt extension.

Example now supported:
-whatsnew-en-US
-whatsnew-en-US.txt

 ## changes

-Added test coverage for  .txt release note files.
-Updated locale extraction to correctly handle files with extensions.
-Verified all tests pass